### PR TITLE
On MacOS Ventura, the say command that Toisto uses for speech does no…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
 dist
+htmlcov
 venv
 .coverage
 .vscode

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Toisto will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v0.0.13 - unreleased
+
+### Fixed
+
+- On MacOS Ventura, the say command that Toisto uses for speech does not print the spoken text, even when told to. Work-around the issue by having Toisto print the question itself.
+
 ## v0.0.12 - 2022-10-30
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "Toisto"
-version = "0.0.12"
+version = "0.0.13"
 authors = [
   { name="Frank Niessink", email="frank@niessink.com" },
 ]

--- a/src/toisto/command/practice.py
+++ b/src/toisto/command/practice.py
@@ -9,6 +9,7 @@ from toisto.speech import say
 def do_quiz(quiz: Quiz, progress: Progress) -> None:
     """Do one quiz and update the progress."""
     console.print(instruction(quiz))
+    console.print(quiz.question)
     say(quiz.question_language, quiz.question)
     guess = Label(input("> "))
     correct = quiz.is_correct(guess)

--- a/src/toisto/speech.py
+++ b/src/toisto/speech.py
@@ -10,4 +10,4 @@ def say(language: str, text: str) -> None:
     """Say the text in the specified language."""
     voice = VOICES[language]
     text = text.replace("'", r"\'")
-    os.system(f"say --voice={voice} --interactive=bold {text}")
+    os.system(f"say --voice={voice} {text}")

--- a/tests/toisto/test_speech.py
+++ b/tests/toisto/test_speech.py
@@ -13,4 +13,4 @@ class SayTest(unittest.TestCase):
     def test_system_call(self, mock_os_system):
         """Test that the say program is called with the correct arguments."""
         say("nl", "Hallo")
-        mock_os_system.assert_called_once_with("say --voice=Xander --interactive=bold Hallo")
+        mock_os_system.assert_called_once_with("say --voice=Xander Hallo")


### PR DESCRIPTION
…t print the spoken text, even when told to. Work-around the issue by having Toisto print the question itself.