### PR TITLE
Allow for specifying spelling variants using the pipe symbol, e.g. "I…

### DIFF
--- a/docs/software.md
+++ b/docs/software.md
@@ -32,9 +32,22 @@ Concepts are represented in the topic files as JSON mappings with language ident
 
 When using more than two languages is not essential to explain how things work, examples below may contain just two languages.
 
+### Spelling variants
+
+When there are multiple ways to spell a label, use the pipe symbol to separate the alternatives. Toisto will only use the first of the alternatives to quiz the user, but will accept the other alternatives as answer.
+
+```json
+[
+    {
+        "en": "Tomorrow it is Tuesday|Tomorrow it's Tuesday",
+        "fi": "Huomenna on tiistai"
+    }
+]
+```
+
 ### Concepts with multiple labels
 
-Labels consist of either one string or a list of strings. A list of strings is used when there are multiple equivalent ways to express the concept in a language, as with "Mikä päivä tänään on?" and "Mikä päivä on tänään?" below.
+Labels consist of either one string or a list of strings. A list of strings is used when there are multiple equivalent ways to express the concept in a language, as with "Mikä päivä tänään on?" and "Mikä päivä on tänään?" below. Toiso will quiz the user with each synonym, so in the example below users practicing Finnish will be asked to translate both Finnish sentences.
 
 ```json
 [
@@ -122,7 +135,7 @@ When concepts, usually verbs and pronouns, have different persons, these are rep
 The format of the JSON files is as follows:
 
 ```json
-
+[
     {
         "singular": {
             "first_person": {
@@ -203,66 +216,24 @@ Degrees of comparison are specified as follows:
 ]
 ```
 
-When there are synonyms, the concept needs to be split as explained above. The specification below prevents Toisto from considering "Suurin" a superlative of "Iso".
+When there are synonyms, they need to be in the same order in every degree. This makes sure Toisto does not consider "Suurin" a superlative of "Iso".
 
 ```json
 [
     {
-        "en": "Big",
-        "fi": ["Iso", "Suuri"],
-        "nl": "Groot"
-    },
-    {
-        "en": "Bigger",
-        "fi": ["Isompi", "Suurempi"],
-        "nl": "Groter"
-    },
-    {
-        "en": "Biggest",
-        "fi": ["Isoin", "Suurin"],
-        "nl": "Grootst"
-    },
-    {
         "positive_degree": {
-            "en": "Big"
-        },
-        "comparitive_degree": {
-            "en": "Bigger"
-        },
-        "superlative_degree": {
-            "en": "Biggest"
-        }
-    },
-    {
-        "positive_degree": {
-            "fi": "Iso"
-        },
-        "comparitive_degree": {
-            "fi": "Isompi"
-        },
-        "superlative_degree": {
-            "fi": "Isoin"
-        }
-    },
-    {
-        "positive_degree": {
-            "fi": "Suuri"
-        },
-        "comparitive_degree": {
-            "fi": "Suurempi"
-        },
-        "superlative_degree": {
-            "fi": "Suurin"
-        }
-    },
-    {
-        "positive_degree": {
+            "en": "Big",
+            "fi": ["Iso", "Suuri"],
             "nl": "Groot"
         },
         "comparitive_degree": {
+            "en": "Bigger",
+            "fi": ["Isompi", "Suurempi"],
             "nl": "Groter"
         },
         "superlative_degree": {
+            "en": "Biggest",
+            "fi": ["Isoin", "Suurin"],
             "nl": "Grootst"
         }
     }

--- a/src/toisto/output.py
+++ b/src/toisto/output.py
@@ -78,7 +78,7 @@ def feedback_correct(guess: Label, quiz: Quiz, quiz_progress: QuizProgress) -> s
 
 def feedback_incorrect(guess: Label, quiz: Quiz) -> str:
     """Return the feedback about an incorrect result."""
-    diff = colored_diff(guess, quiz.get_answer())
+    diff = colored_diff(guess, quiz.answer)
     return f'❌ Incorrect. The correct answer is "{diff}".\n'
 
 

--- a/src/toisto/topics/counting.json
+++ b/src/toisto/topics/counting.json
@@ -7,11 +7,7 @@
     {
         "en": "One",
         "fi": "Yksi",
-        "nl": [
-            "Eén",
-            "één",
-            "Een"
-        ]
+        "nl": "Eén|één|Een"
     },
     {
         "en": "Two",

--- a/src/toisto/topics/days.json
+++ b/src/toisto/topics/days.json
@@ -133,18 +133,12 @@
         "nl": "Volgende week"
     },
     {
-        "en": [
-            "Today it is Monday",
-            "Today it's Monday"
-        ],
+        "en": "Today it is Monday|Today it's Monday",
         "fi": "Tänään on maanantai",
         "nl": "Vandaag is het maandag"
     },
     {
-        "en": [
-            "Tomorrow it is Tuesday",
-            "Tomorrow it's Tuesday"
-        ],
+        "en": "Tomorrow it is Tuesday|Tomorrow it's Tuesday",
         "fi": "Huomenna on tiistai",
         "nl": "Morgen is het dinsdag"
     },

--- a/src/toisto/topics/degrees_of_comparison.json
+++ b/src/toisto/topics/degrees_of_comparison.json
@@ -449,7 +449,7 @@
         },
         "comparitive_degree": {
             "en": "Nicer",
-            "fi": ["Kivampi", "Mukavampi"],
+            "fi": ["Kivampi|Kivempt", "Mukavampi"],
             "nl": "Leuker"
         },
         "superlative_degree": {

--- a/src/toisto/topics/food.json
+++ b/src/toisto/topics/food.json
@@ -24,12 +24,12 @@
     },
     {
         "singular": {
-            "en": ["Hotdog", "Hot dog"],
+            "en": ["Hotdog|Hot dog"],
             "fi": "Hotdog",
             "nl": "De hotdog"
         },
         "plural": {
-            "en": ["Hotdogs", "Hot dogs"],
+            "en": ["Hotdogs|Hot dogs"],
             "fi": "Hotdogit",
             "nl": "De hotdogs"
         }

--- a/src/toisto/topics/greetings.json
+++ b/src/toisto/topics/greetings.json
@@ -56,10 +56,7 @@
         "nl": "Mijn naam is Bob"
     },
     {
-        "en": [
-            "I am Alice",
-            "I'm Alice"
-        ],
+        "en": "I am Alice|I'm Alice",
         "fi": "Minä olen Alice",
         "nl": "Ik ben Alice"
     },

--- a/src/toisto/topics/months.json
+++ b/src/toisto/topics/months.json
@@ -75,10 +75,7 @@
         "nl": "December"
     },
     {
-        "en": [
-            "It is July",
-            "It's July"
-        ],
+        "en": "It is July|It's July",
         "fi": [
             "Nyt on heinäkuu",
             "On heinäkuu"

--- a/src/toisto/topics/verbs.json
+++ b/src/toisto/topics/verbs.json
@@ -2,72 +2,72 @@
     {
         "singular": {
             "first_person": {
-                "en": "I have",
+                "en": "I have|I've",
                 "fi": "Minulla on",
                 "nl": "Ik heb"
             },
             "second_person": {
-                "en": "You have",
+                "en": "You have|You've",
                 "fi": "Sinulla on",
-                "nl": ["Jij hebt", "Je hebt"]
+                "nl": "Jij hebt|Je hebt"
             },
             "third_person": {
-                "en": ["He has", "She has"],
-                "nl": ["Hij heeft", "Zij heeft", "Ze heeft"],
+                "en": ["He has|He's", "She has|She's"],
+                "nl": ["Hij heeft", "Zij heeft|Ze heeft"],
                 "fi": "Hänellä on"
             }
         },
         "plural": {
             "first_person": {
-                "en": "We have",
+                "en": "We have|We've",
                 "fi": "Meillä on",
-                "nl": ["Wij hebben", "We hebben"]
+                "nl": "Wij hebben|We hebben"
             },
             "second_person": {
-                "en": "You have",
+                "en": "You have|You've",
                 "fi": "Teillä on",
                 "nl": "Jullie hebben"
             },
             "third_person": {
-                "en": "They have",
+                "en": "They have|They've",
                 "fi": "Heillä on",
-                "nl": ["Zij hebben", "Ze hebben"]
+                "nl": "Zij hebben|Ze hebben"
             }
         }
     },
     {
         "singular": {
             "first_person": {
-                "en": "I am",
-                "fi": ["Minä olen", "Olen"],
+                "en": "I am|I'm",
+                "fi": "Minä olen|Olen",
                 "nl": "Ik ben"
             },
             "second_person": {
-                "en": "You are",
-                "fi": ["Sinä olet", "Olet"],
-                "nl": ["Jij bent", "Je bent"]
+                "en": "You are|You're",
+                "fi": "Sinä olet|Olet",
+                "nl": "Jij bent|Je bent"
             },
             "third_person": {
-                "en": ["He is", "She is"],
-                "fi": ["Hän on", "On"],
-                "nl": ["Hij is", "Zij is", "Ze is"]
+                "en": ["He is|He's", "She is|She's"],
+                "fi": "Hän on|On",
+                "nl": ["Hij is", "Zij is|Ze is"]
             }
         },
         "plural": {
             "first_person": {
-                "en": "We are",
-                "fi": ["Me olemme", "Olemme"],
-                "nl": ["Wij zijn", "We zijn"]
+                "en": "We are|We're",
+                "fi": "Me olemme|Olemme",
+                "nl": "Wij zijn|We zijn"
             },
             "second_person": {
-                "en": "You are",
-                "fi": ["Te olette", "Olette"],
+                "en": "You are|You're",
+                "fi": "Te olette|Olette",
                 "nl": "Jullie zijn"
             },
             "third_person": {
-                "en": "They are",
-                "fi": ["He ovat", "Ovat"],
-                "nl": ["Zij zijn", "ze zijn"]
+                "en": "They are|They're",
+                "fi": "He ovat|Ovat",
+                "nl": "Zij zijn|Ze zijn"
             }
         }
     }

--- a/tests/toisto/model/test_quiz.py
+++ b/tests/toisto/model/test_quiz.py
@@ -22,12 +22,12 @@ class QuizTest(unittest.TestCase):
 
     def test_get_answer(self):
         """Test that the answer is returned."""
-        self.assertEqual("Engels", self.quiz.get_answer())
+        self.assertEqual("Engels", self.quiz.answer)
 
     def test_get_first_answer(self):
         """Test that the first answer is returned when there are multiple."""
         quiz = Quiz("fi", "nl", "Yksi", ["Een", "Eén"])
-        self.assertEqual("Een", quiz.get_answer())
+        self.assertEqual("Een", quiz.answer)
 
     def test_other_answers(self):
         """Test that the other answers can be retrieved."""
@@ -37,3 +37,28 @@ class QuizTest(unittest.TestCase):
     def test_instruction(self):
         """Test the quiz instruction."""
         self.assertEqual("Translate into Dutch", self.quiz.instruction())
+
+    def test_spelling_alternative_of_answer(self):
+        """Test that a quiz can deal with alternative spellings of answers."""
+        quiz = Quiz("fi", "nl", "Yksi", ["Een|Eén"])
+        self.assertEqual("Een", quiz.answer)
+
+    def test_spelling_alternative_of_question(self):
+        """Test that a quiz can deal with alternative spellings of the question."""
+        quiz = Quiz("nl", "fy", "Een|Eén", ["Yksi"])
+        self.assertEqual("Een", quiz.question)
+
+    def test_spelling_alternative_is_correct(self):
+        """Test that an answer that matches a spelling alternative is correct."""
+        quiz = Quiz("fi", "nl", "Yksi", ["Een|Eén", "één"])
+        for alternative in ("Een", "Eén", "één"):
+            self.assertTrue(quiz.is_correct(alternative))
+
+    def test_other_answers_with_spelling_alternatives(self):
+        """Test the spelling alternatives are returned as other answers."""
+        quiz = Quiz("fi", "nl", "Yksi", ["Een|Eén", "één"])
+        alternatives = ("Een", "Eén", "één")
+        for alternative in alternatives:
+            other_answers = list(alternatives)
+            other_answers.remove(alternative)
+            self.assertEqual(other_answers, quiz.other_answers(alternative))


### PR DESCRIPTION
… am Alice|I'm Alice".