### PR TITLE
When selecting new quizzes for the user to answer, do so in the order…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,15 @@ All notable changes to Toisto will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.0.15 - 2022-11-07
+## v0.0.15 - 2022-11-08
 
-- Fix the Dutch label for shortest in the degrees of comparison topic.
+### Fixed
+
+- Fix the Dutch label for "shortest" in the degrees of comparison topic.
+
+### Added
+
+- When selecting new quizzes for the user to answer, do so in the order of topics and order of concepts in the topic files. This makes sure the user will be quizzed on concepts and topics concepts they have already been working on, before being introduced to new concepts and topics. Closes [#32](https://github.com/fniessink/toisto/issues/32).
 
 ## v0.0.14 - 2022-11-06
 

--- a/src/toisto/metadata.py
+++ b/src/toisto/metadata.py
@@ -14,5 +14,5 @@ SUPPORTED_LANGUAGES = dict(en="English", fi="Finnish", nl="Dutch")
 Language = Literal["en", "fi", "nl"]
 
 _topics_folder = pathlib.Path(__file__).parent / "topics"
-TOPIC_JSON_FILES = list(_topics_folder.glob("*.json"))
-TOPICS = sorted(json_file.stem for json_file in TOPIC_JSON_FILES)
+TOPIC_JSON_FILES = sorted(list(_topics_folder.glob("*.json")))
+TOPICS = [json_file.stem for json_file in TOPIC_JSON_FILES]

--- a/src/toisto/model/progress.py
+++ b/src/toisto/model/progress.py
@@ -30,7 +30,8 @@ class Progress:
         """Return eligible quizzes."""
         eligible_quizzes = [quiz for quiz in quizzes if not self.__is_silenced(quiz) and quiz != self.__current_quiz]
         quizzes_with_progress = [quiz for quiz in eligible_quizzes if self.__has_progress(quiz)]
-        return eligible_quizzes if len(quizzes_with_progress) < 3 else quizzes_with_progress
+        quizzes_without_progress = [quiz for quiz in eligible_quizzes if not self.__has_progress(quiz)]
+        return quizzes_without_progress[:3] if len(quizzes_with_progress) < 3 else quizzes_with_progress
 
     def __is_silenced(self, quiz: Quiz) -> bool:
         """Is the quiz silenced?"""


### PR DESCRIPTION
… of topics and order of concepts in the topic files. This makes sure the user will be quizzed on concepts and topics concepts they have already been working on, before being introduced to new concepts and topics. Closes #32.