### PR TITLE
When showing the meaning of a concept, show only the first spelling variant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,11 @@ All notable changes to Toisto will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## v0.2.0 - 2022-11-27
+## v0.2.0 - 2022-11-29
+
+### Fixed
+
+- When showing the meaning of a concept, show only the first spelling variant. Fixes [#63](https://github.com/fniessink/toisto/issues/63).
 
 ### Added
 

--- a/src/toisto/model/quiz/quiz.py
+++ b/src/toisto/model/quiz/quiz.py
@@ -57,7 +57,7 @@ class Quiz:  # pylint: disable=too-many-instance-attributes
     _answers: Labels
     quiz_type: QuizType = "translate"
     uses: tuple[ConceptId, ...] = tuple()
-    meaning: Label = Label()
+    _meaning: Label = Label()
 
     def __str__(self) -> str:
         """Return a string version of the quiz that can be used as key in the progress dict."""
@@ -101,6 +101,11 @@ class Quiz:  # pylint: disable=too-many-instance-attributes
         """Return all answers."""
         answers = [answer.spelling_alternatives() for answer in self._answers]
         return cast(Labels, tuple(chain(*answers)))
+
+    @property
+    def meaning(self) -> Label:
+        """Return the first spelling alternative of the meaning."""
+        return self._meaning.first_spelling_alternative()
 
     def other_answers(self, guess: Label) -> Labels:
         """Return the answers not equal to the guess."""

--- a/tests/toisto/base.py
+++ b/tests/toisto/base.py
@@ -32,5 +32,5 @@ class ToistoTestCase(unittest.TestCase):
             tuple(Label(answer) for answer in answers),
             cast(QuizType, quiz_type),
             uses,
-            cast(Label, meaning)
+            Label(meaning)
         )


### PR DESCRIPTION
Fixes #63.