### PR TITLE
Toisto would show empty strings as meaning if the quizzed concept has…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - When showing the correct answer, replace inserted or removed spaces with an underscore so it is more clear what the user would have needed to type differently to enter the correct answer. Fixes [#96](https://github.com/fniessink/toisto/issues/96).
 - Apostrophes were ignored when checking answers. Fixes [#97](https://github.com/fniessink/toisto/issues/97).
+- Toisto would show empty strings as meaning if the quizzed concept has no label in the user's language. Fixes [#101](https://github.com/fniessink/toisto/issues/101).
 
 ## v0.3.0 - 2022-12-04
 

--- a/src/toisto/model/language/concept.py
+++ b/src/toisto/model/language/concept.py
@@ -58,8 +58,7 @@ class LeafConcept(Concept):
     def quizzes(self, language: Language, source_language: Language) -> Quizzes:
         """Generate the possible quizzes from the concept and its labels."""
         labels, source_labels = self.labels(language), self.labels(source_language)
-        meaning = self.meaning(source_language)
-        meanings = (meaning,) if meaning else ()
+        meanings = self.meanings(source_language)
         translate = quiz_factory(self.concept_id, language, source_language, labels, source_labels, uses=self._uses)
         listen = quiz_factory(self.concept_id, language, language, labels, labels, ("listen",), self._uses, meanings)
         return translate | listen
@@ -72,9 +71,10 @@ class LeafConcept(Concept):
         """Return self as a list of leaf concepts."""
         return [self]
 
-    def meaning(self, language: Language) -> Label:
+    def meanings(self, language: Language) -> Labels:
         """Return the meaning of the concept in the specified language."""
-        return Label(self._labels.get(language, [""])[0])
+        meaning = Label(self._labels.get(language, [""])[0])
+        return (meaning,) if meaning else ()
 
     @classmethod
     def from_dict(cls, concept_id: ConceptId, concept_dict: LeafConceptDict) -> LeafConcept:
@@ -110,7 +110,7 @@ class CompositeConcept(Concept):
             quiz_type = self.grammatical_quiz_type(concept1, concept2)
             labels1, labels2 = concept1.labels(language), concept2.labels(language)
             uses = self._uses + (concept2.concept_id,)
-            meanings = concept1.meaning(source_language), concept2.meaning(source_language)
+            meanings = concept1.meanings(source_language) + concept2.meanings(source_language)
             result.update(quiz_factory(concept_id, language, language, labels1, labels2, (quiz_type,), uses, meanings))
         return result
 

--- a/tests/toisto/model/language/test_concept.py
+++ b/tests/toisto/model/language/test_concept.py
@@ -62,6 +62,7 @@ class ConceptQuizzesTest(ToistoTestCase):
         concept = concept_factory(
             "ketchup", dict(singular=dict(fi="Ketsuppi", nl="De ketchup"), plural=dict(fi="Ketsupit"))
         )
+        quizzes = concept.quizzes("fi", "nl")
         self.assertEqual(
             set([
                 self.create_quiz("ketchup", "fi", "nl", "Ketsuppi", ["De ketchup"]),
@@ -71,12 +72,15 @@ class ConceptQuizzesTest(ToistoTestCase):
                 self.create_quiz("ketchup", "fi", "fi", "Ketsuppi", ["Ketsupit"], "pluralize"),
                 self.create_quiz("ketchup", "fi", "fi", "Ketsupit", ["Ketsuppi"], "singularize")
             ]),
-            concept.quizzes("fi", "nl")
+            quizzes
         )
+        for quiz in quizzes:
+            self.assertNotIn("", (str(meaning) for meaning in quiz.meanings))
 
     def test_grammatical_number_with_one_language(self):
         """Test that quizzes can be generated from a concept with labels in the practice language only."""
         concept = concept_factory("mämmi", dict(singular=dict(fi="Mämmi"), plural=dict(fi="Mämmit")))
+        quizzes = concept.quizzes("fi", "en")
         self.assertEqual(
             set([
                 self.create_quiz("mämmi", "fi", "fi", "Mämmi", ["Mämmi"], "listen"),
@@ -84,8 +88,10 @@ class ConceptQuizzesTest(ToistoTestCase):
                 self.create_quiz("mämmi", "fi", "fi", "Mämmi", ["Mämmit"], "pluralize"),
                 self.create_quiz("mämmi", "fi", "fi", "Mämmit", ["Mämmi"], "singularize")
             ]),
-            concept.quizzes("fi", "en")
+            quizzes
         )
+        for quiz in quizzes:
+            self.assertNotIn("", (str(meaning) for meaning in quiz.meanings))
 
     def test_grammatical_number_with_one_language_reversed(self):
         """Test that no quizzes can be generated from a noun concept with labels in the native language."""

--- a/tests/toisto/model/quiz/test_quiz.py
+++ b/tests/toisto/model/quiz/test_quiz.py
@@ -46,10 +46,6 @@ class QuizTest(QuizTestCase):
         quiz = self.create_quiz("1", "fi", "nl", "Yksi", ["Een", "Eén;hint should be ignored"], "listen")
         self.assertEqual((), quiz.other_answers("Een"))
 
-    def test_instruction(self):
-        """Test the quiz instruction."""
-        self.assertEqual("Translate into Dutch", self.quiz.instruction())
-
     def test_spelling_alternative_of_answer(self):
         """Test that a quiz can deal with alternative spellings of answers."""
         quiz = self.create_quiz("1", "fi", "nl", "Yksi", ["Een|Eén"])


### PR DESCRIPTION
… no label in the user's language. Fixes #101.