### PR TITLE
Save progress for different target languages in different files. The …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ Unfortunately, this version is backwards incompatible and progress information f
 
 - Allow for specifying the meaning of concepts that have no label in a language. Closes [#138](https://github.com/fniessink/toisto/issues/138).
 
+### Changed
+
+- Save progress for different target languages in different files. The progress files are saved in the user's home directory as before, but now include the target language in the filename, for example `/home/user/.toisto-progress-fi.json`. Closes [#271](https://github.com/fniessink/toisto/issues/271).
+
 ## 0.8.2 - 2023-02-18
 
 ### Fixed

--- a/docs/software.md
+++ b/docs/software.md
@@ -517,7 +517,9 @@ If a user knows the correct answer the first time a quiz is presented, the quiz 
 
 ## Progress savefile
 
-When the program is stopped, progress is saved in a file named `.toisto-progress.json` in the user's home folder. Each entry in the file is the progress of one specific quiz. The key denotes the quiz, the value contains information about the user's retention of the quiz. This looks as follows:
+When the program is stopped, progress is saved in a file named `.toisto-progress-{target language}.json` in the user's home folder, for example `.toisto-progress-fi.json`. So each target language gets its own progress file.
+
+Each entry in the file is the progress of one specific quiz. The key denotes the quiz, the value contains information about the user's retention of the quiz. This looks as follows:
 
 ```json
 {

--- a/src/toisto/app.py
+++ b/src/toisto/app.py
@@ -33,7 +33,7 @@ def main() -> None:
         args.topic_file,
         argument_parser,
     )
-    progress = load_progress(topics, argument_parser)
+    progress = load_progress(topics, args.target_language, argument_parser)
     if args.command == "practice":
         show_welcome(latest_version())
         practice(progress, config)

--- a/src/toisto/metadata.py
+++ b/src/toisto/metadata.py
@@ -21,7 +21,12 @@ BUILT_IN_LANGUAGES = [Language("en"), Language("fi"), Language("nl")]
 _data_folder = pathlib.Path(__file__).parent.parent
 TOPIC_JSON_FILES = sorted((_data_folder / "topics").glob("*.json"))
 LANGUAGES_FILE = _data_folder / "languages" / "iana-language-subtag-registry.txt"
-PROGRESS_JSON = pathlib.Path.home() / f".{NAME.lower()}-progress.json"
+
+
+def get_progress_filepath(target_language: Language) -> pathlib.Path:
+    """Return the filename of the progress file for the specified target language."""
+    return pathlib.Path.home() / f".{NAME.lower()}-progress-{target_language}.json"
+
 
 TOPICS = [json_file.stem for json_file in TOPIC_JSON_FILES]
 

--- a/src/toisto/model/quiz/progress.py
+++ b/src/toisto/model/quiz/progress.py
@@ -2,19 +2,23 @@
 
 from collections import deque
 
+from toisto.model.language import Language
 from toisto.model.language.concept import Concept
 
 from .quiz import Quiz, Quizzes
 from .retention import Retention
 from .topic import Topics
 
+ProgressDict = dict[str, dict[str, str | int]]
+
 
 class Progress:
     """Keep track of progress on quizzes."""
 
-    def __init__(self, progress_dict: dict[str, dict[str, str | int]], topics: Topics) -> None:
+    def __init__(self, progress_dict: ProgressDict, topics: Topics, target_language: Language) -> None:
         self.__progress_dict = {key: Retention.from_dict(value) for key, value in progress_dict.items()}
         self.__topics = topics
+        self.target_language = target_language
         self.__recent_concepts: deque[Concept] = deque(maxlen=2)  # Recent concepts to skip when selecting next quiz
         self.__quizzes_by_concept: dict[Concept, Quizzes] = {}
         for quiz in self.__topics.quizzes:

--- a/src/toisto/persistence/progress.py
+++ b/src/toisto/persistence/progress.py
@@ -3,27 +3,30 @@
 from argparse import ArgumentParser
 from typing import NoReturn
 
-from ..metadata import NAME, PROGRESS_JSON
+from ..metadata import NAME, get_progress_filepath
+from ..model.language import Language
 from ..model.quiz.progress import Progress
 from ..model.quiz.topic import Topics
 from .json_file import dump_json, load_json
 
 
-def load_progress(topics: Topics, argument_parser: ArgumentParser) -> Progress | NoReturn:
+def load_progress(topics: Topics, target_language: Language, argument_parser: ArgumentParser) -> Progress | NoReturn:
     """Load the progress from the user's home folder."""
+    progress_filepath = get_progress_filepath(target_language)
     try:
-        progress_dict = load_json(PROGRESS_JSON, default={})
+        progress_dict = load_json(progress_filepath, default={})
     except Exception as reason:  # noqa: BLE001
         return argument_parser.error(
-            f"""{NAME} cannot parse the progress information in {PROGRESS_JSON}: {reason}.
-To fix this, remove or rename {PROGRESS_JSON} and start {NAME} again. Unfortunately, this will reset your progress.
+            f"""{NAME} cannot parse the progress information in {progress_filepath}: {reason}.
+To fix this, remove or rename {progress_filepath} and start {NAME} again. Unfortunately, this will reset your progress.
 Please consider opening a bug report at https://github.com/fniessink/{NAME.lower()}. Be sure to attach the invalid
 progress file to the issue.
 """,
         )
-    return Progress(progress_dict, topics)
+    return Progress(progress_dict, topics, target_language)
 
 
 def save_progress(progress: Progress) -> None:
     """Save the progress to the user's home folder."""
-    dump_json(PROGRESS_JSON, progress.as_dict())
+    progress_filepath = get_progress_filepath(progress.target_language)
+    dump_json(progress_filepath, progress.as_dict())

--- a/tests/toisto/command/test_practice.py
+++ b/tests/toisto/command/test_practice.py
@@ -4,6 +4,7 @@ from configparser import ConfigParser
 from unittest.mock import MagicMock, Mock, call, patch
 
 from toisto.command.practice import practice
+from toisto.model.language import Language
 from toisto.model.language.concept import ConceptId
 from toisto.model.quiz.progress import Progress
 from toisto.model.quiz.topic import Topic, Topics
@@ -24,7 +25,7 @@ class PracticeTest(ToistoTestCase):
         self.concept = self.create_concept(ConceptId("hi"))
         quiz = self.create_quiz(self.concept, "fi", "nl", "Terve", ["Hoi"])
         topics = Topics({Topic("topic", (), {quiz})})
-        self.progress = Progress({}, topics)
+        self.progress = Progress({}, topics, Language("fi"))
 
     def practice(self, progress: Progress | None = None) -> Mock:
         """Run the practice command and return the patch print statement."""
@@ -59,7 +60,7 @@ class PracticeTest(ToistoTestCase):
         """Test that the question is not printed on a listening quiz."""
         quiz = self.create_quiz(self.concept, "fi", "fi", "Terve", ["Terve"], "listen")
         topics = Topics({Topic("topic", (), {quiz})})
-        patched_print = self.practice(Progress({}, topics))
+        patched_print = self.practice(Progress({}, topics, "fi"))
         self.assertNotIn(call(linkify("Terve")), patched_print.call_args_list)
 
     @patch("builtins.input", Mock(return_value="Terve\n"))
@@ -67,7 +68,7 @@ class PracticeTest(ToistoTestCase):
         """Test that the translation is not printed on a non-translate quiz."""
         quiz = self.create_quiz(self.concept, "fi", "fi", "Terve", ["Terve"], "listen", meanings=("Hoi",))
         topics = Topics({Topic("topic", (), {quiz})})
-        patched_print = self.practice(Progress({}, topics))
+        patched_print = self.practice(Progress({}, topics, "fi"))
         expected_text = f'✅ Correct.\n[secondary]Meaning "{linkify("Hoi")}".[/secondary]\n'
         self.assertIn(call(expected_text), patched_print.call_args_list)
 
@@ -77,7 +78,7 @@ class PracticeTest(ToistoTestCase):
         concept = self.create_concept("house")
         quiz = self.create_quiz(concept, "fi", "fi", "Talo", ["Talot"], "pluralize", meanings=("Huis", "Huizen"))
         topics = Topics({Topic("topic", (), {quiz})})
-        patched_print = self.practice(Progress({}, topics))
+        patched_print = self.practice(Progress({}, topics, "fi"))
         expected_text = f'✅ Correct.\n[secondary]Meaning "{linkify("Huis")}", "{linkify("Huizen")}".[/secondary]\n'
         self.assertIn(call(expected_text), patched_print.call_args_list)
 

--- a/tests/toisto/command/test_show_progress.py
+++ b/tests/toisto/command/test_show_progress.py
@@ -22,7 +22,7 @@ class ShowProgressTest(ToistoTestCase):
     def test_title(self):
         """Test the table title."""
         with patch("rich.console.Console.print") as console_print:
-            show_progress("fi", Topics(), Progress({}, self.topics))
+            show_progress("fi", Topics(), Progress({}, self.topics, "fi"))
         self.assertEqual("Progress Finnish", console_print.call_args[0][0].title)
 
     def test_quiz(self):
@@ -31,7 +31,7 @@ class ShowProgressTest(ToistoTestCase):
         start = (now - timedelta(hours=1)).isoformat(timespec="seconds")
         end = now.isoformat(timespec="seconds")
         with patch("rich.console.Console.print") as console_print:
-            show_progress("fi", self.topics, Progress({self.quiz.key: dict(start=start, end=end)}, self.topics))
+            show_progress("fi", self.topics, Progress({self.quiz.key: dict(start=start, end=end)}, self.topics, "fi"))
         for index, value in enumerate(["Read", "Terve!", "fi", "nl", "Hoi!", "0", "60 minutes", ""]):
             self.assertEqual(value, list(console_print.call_args[0][0].columns[index].cells)[0])
 
@@ -39,14 +39,14 @@ class ShowProgressTest(ToistoTestCase):
         """Test that if the time until which a quiz is silenced lies in the future, it is shown."""
         skip_until = (datetime.now() + timedelta(days=1)).isoformat(sep=" ", timespec="minutes")
         with patch("rich.console.Console.print") as console_print:
-            show_progress("fi", self.topics, Progress({self.quiz.key: dict(skip_until=skip_until)}, self.topics))
+            show_progress("fi", self.topics, Progress({self.quiz.key: dict(skip_until=skip_until)}, self.topics, "fi"))
         self.assertEqual(skip_until, list(console_print.call_args[0][0].columns[7].cells)[0])
 
     def test_quiz_silenced_until_time_in_the_past(self):
         """Test that if the time until which a quiz is silenced lies in the past, it is not shown."""
         skip_until = (datetime.now() - timedelta(days=1)).isoformat(sep=" ", timespec="minutes")
         with patch("rich.console.Console.print") as console_print:
-            show_progress("fi", self.topics, Progress({self.quiz.key: dict(skip_until=skip_until)}, self.topics))
+            show_progress("fi", self.topics, Progress({self.quiz.key: dict(skip_until=skip_until)}, self.topics, "fi"))
         self.assertEqual("", list(console_print.call_args[0][0].columns[7].cells)[0])
 
     def test_sort_by_retention(self):
@@ -60,6 +60,7 @@ class ShowProgressTest(ToistoTestCase):
         progress = Progress(
             {self.quiz.key: dict(count=21, start=start, end=end), another_quiz.key: dict(count=42)},
             self.topics,
+            "fi",
         )
         with patch("rich.console.Console.print") as console_print:
             show_progress("fi", topics, progress, sort="retention")

--- a/tests/toisto/model/quiz/test_progress.py
+++ b/tests/toisto/model/quiz/test_progress.py
@@ -2,6 +2,7 @@
 
 from typing import get_args
 
+from toisto.model.language import Language
 from toisto.model.language.concept import ConceptId
 from toisto.model.quiz.progress import Progress
 from toisto.model.quiz.quiz import Quizzes, TranslationQuizType
@@ -19,12 +20,12 @@ class ProgressTest(ToistoTestCase):
         self.concept = self.create_concept(ConceptId("english"))
         self.quiz = self.create_quiz(self.concept, "fi", "nl", "Englanti", ["Engels"])
         self.another_quiz = self.create_quiz(self.concept, "nl", "fi", "Engels", ["Englanti"])
-        self.progress = Progress({}, Topics(set()))
+        self.progress = Progress({}, Topics(set()), Language("fi"))
 
     def create_progress(self, *topic_quizzes: Quizzes) -> Progress:
         """Create progress for the quizzes."""
         topics = Topics({Topic(f"topic{index}", (), quizzes) for index, quizzes in enumerate(topic_quizzes)})
-        return Progress({}, topics)
+        return Progress({}, topics, Language("fi"))
 
     def test_progress_new_quiz(self):
         """Test that a new quiz has no progress."""
@@ -119,7 +120,7 @@ class ProgressTest(ToistoTestCase):
     def test_next_quiz_is_quiz_with_progress(self):
         """Test that the next quiz is one the user has seen before if possible."""
         concepts = [self.create_concept(f"id{index}", dict(fi=f"fi{index}", nl=f"nl{index}")) for index in range(5)]
-        quizzes = list(QuizFactory("nl", "fi").create_quizzes(*concepts))
+        quizzes = list(QuizFactory("fi", "nl").create_quizzes(*concepts))
         progress = self.create_progress(quizzes)
         for index in range(3):
             progress.increase_retention(quizzes[index])

--- a/tests/toisto/persistence/test_progress.py
+++ b/tests/toisto/persistence/test_progress.py
@@ -4,10 +4,12 @@ import unittest
 from argparse import ArgumentParser
 from unittest.mock import MagicMock, Mock, patch
 
+from toisto.metadata import get_progress_filepath
+from toisto.model.language import Language
 from toisto.model.quiz.progress import Progress
 from toisto.model.quiz.retention import Retention
 from toisto.model.quiz.topic import Topics
-from toisto.persistence.progress import PROGRESS_JSON, load_progress, save_progress
+from toisto.persistence.progress import load_progress, save_progress
 
 
 class ProgressPersistenceTest(unittest.TestCase):
@@ -17,7 +19,7 @@ class ProgressPersistenceTest(unittest.TestCase):
     @patch("pathlib.Path.open", MagicMock())
     def test_load_non_existing_progress(self):
         """Test that the default value is returned when the progress cannot be loaded."""
-        self.assertEqual({}, load_progress(Topics(set()), ArgumentParser()).as_dict())
+        self.assertEqual({}, load_progress(Topics(set()), "fi", ArgumentParser()).as_dict())
 
     @patch("pathlib.Path.exists", Mock(return_value=True))
     @patch("sys.stderr.write")
@@ -25,22 +27,27 @@ class ProgressPersistenceTest(unittest.TestCase):
     def test_load_invalid_progress(self, path_open: Mock, stderr_write: Mock):
         """Test that the the program exists if the progress cannot be loaded."""
         path_open.return_value.__enter__.return_value.read.return_value = ""
-        self.assertRaises(SystemExit, load_progress, Topics(set()), ArgumentParser())
-        self.assertIn(f"cannot parse the progress information in {PROGRESS_JSON}", stderr_write.call_args_list[1][0][0])
+        language = Language("en")
+        self.assertRaises(SystemExit, load_progress, Topics(set()), language, ArgumentParser())
+        progress_file = get_progress_filepath(language)
+        self.assertIn(f"cannot parse the progress information in {progress_file}", stderr_write.call_args_list[1][0][0])
 
     @patch("pathlib.Path.exists", Mock(return_value=True))
     @patch("pathlib.Path.open")
     def test_load_existing_progress(self, path_open: Mock):
         """Test that the progress can be loaded."""
         path_open.return_value.__enter__.return_value.read.return_value = '{"quiz": {}}'
-        self.assertEqual(dict(quiz=Retention().as_dict()), load_progress(Topics(set()), ArgumentParser()).as_dict())
+        self.assertEqual(
+            dict(quiz=Retention().as_dict()),
+            load_progress(Topics(set()), Language("nl"), ArgumentParser()).as_dict(),
+        )
 
     @patch("pathlib.Path.open")
     @patch("json.dump")
     def test_save_empty_progress(self, dump: Mock, path_open: Mock):
         """Test that the progress can be saved."""
         path_open.return_value.__enter__.return_value = json_file = MagicMock()
-        save_progress(Progress({}, Topics(set())))
+        save_progress(Progress({}, Topics(set()), Language("fi")))
         dump.assert_called_once_with({}, json_file)
 
     @patch("pathlib.Path.open")
@@ -48,7 +55,7 @@ class ProgressPersistenceTest(unittest.TestCase):
     def test_save_incorrect_only_progress(self, dump: Mock, path_open: Mock):
         """Test that the progress can be saved."""
         path_open.return_value.__enter__.return_value = json_file = MagicMock()
-        save_progress(Progress(dict(quiz={}), Topics(set())))
+        save_progress(Progress(dict(quiz={}), Topics(set()), Language("fi")))
         dump.assert_called_once_with(dict(quiz={}), json_file)
 
     @patch("pathlib.Path.open")
@@ -56,5 +63,5 @@ class ProgressPersistenceTest(unittest.TestCase):
     def test_save_progress(self, dump: Mock, path_open: Mock):
         """Test that the progress can be saved."""
         path_open.return_value.__enter__.return_value = json_file = MagicMock()
-        save_progress(Progress(dict(quiz=dict(skip_until="3000-01-01")), Topics(set())))
+        save_progress(Progress(dict(quiz=dict(skip_until="3000-01-01")), Topics(set()), Language("fi")))
         dump.assert_called_once_with(dict(quiz=dict(skip_until="3000-01-01T00:00:00")), json_file)

--- a/tests/toisto/ui/test_text.py
+++ b/tests/toisto/ui/test_text.py
@@ -2,6 +2,7 @@
 
 from unittest import TestCase
 
+from toisto.model.language import Language
 from toisto.model.language.concept import ConceptId
 from toisto.model.language.label import Label
 from toisto.model.quiz.progress import Progress
@@ -20,7 +21,7 @@ class FeedbackTestCase(ToistoTestCase):
         self.concept = self.create_concept(ConceptId("hello"))
         self.quiz = self.create_quiz(self.concept, "nl", "fi", "Hoi", ["Terve"], meanings=("Hoi",))
         self.guess = Label("Terve")
-        self.progress = Progress({}, Topics(set()))
+        self.progress = Progress({}, Topics(set()), Language("nl"))
 
     def test_correct_first_time(self):
         """Test that the correct feedback is given when the user guesses correctly."""


### PR DESCRIPTION
…progress files are saved in the user's home directory as before, but now include the target language in the filename, for example `/home/user/.toisto-progress-fi.json`. Closes #271.