### PR TITLE
The context information that can be added to labels and that is shown…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Concepts can belong to multiple topics. Closes [#234](https://github.com/fniessink/toisto/issues/234).
 - Added several topics and concepts.
 
+### Changed
+
+- The context information that can be added to labels and that is shown as part of quiz instructions is no longer called a "hint" but a "note". This prepares for supporting notes that are shown after the quiz.
+
 ## 0.10.0 - 2023-04-01
 
 ### Added

--- a/docs/software.md
+++ b/docs/software.md
@@ -78,9 +78,9 @@ When there are multiple ways to spell a label, use the pipe symbol (`|`) to sepa
 }
 ```
 
-### Labels with hints
+### Labels with notes
 
-Sometimes labels are ambiguous. For example, "you" in English can mean both one or multiple persons. To help the user understand which meaning is intended, a hint can be added to the label. The hint is the part after the semicolon (`;`):
+Sometimes labels are ambiguous. For example, "you" in English can mean both one or multiple persons. To help the user understand which meaning is intended, a note can be added to the label. The note is the part after the semicolon (`;`):
 
 ```json
 {
@@ -105,7 +105,7 @@ Sometimes labels are ambiguous. For example, "you" in English can mean both one 
 }
 ```
 
-Toisto will show the hint to the user when asking for the Dutch translation of "you live".
+Toisto will show the note to the user when asking for the Dutch translation of "you live".
 
 ### Concepts with multiple labels
 
@@ -140,7 +140,7 @@ Some concepts have a label in one language, but not in other languages. Mämmi, 
 
 Sometimes a concept in one language can be two different concepts in another language. For example, both in English and Dutch there are separate greetings for the afternoon and the whole day: "Good afternoon" and "Good day" in English and "Goedemiddag" and "Goedendag" in Dutch. In Finnish "Hyvää päivää", or just "Päivää", is used for both. As an aside, "Hyvää iltapäivää", although grammatically correct, is not used.
 
-If we would include all these labels in one concept, Toisto would consider "Goedemiddag" a correct translation of "Good day", which is undesirable. The solution is to have two concepts, one for "good afternoon" and one for "good day". Both concepts get the Finnish labels "Hyvää päivää" and "Päivää". The Finnish labels for the "good afternoon" concept get a hint that Toisto shows when asking for the Dutch or English translation of "Hyvää päivää" or "Päivää" so that the user knows the context. The hint is the part after the semicolon (`;`).
+If we would include all these labels in one concept, Toisto would consider "Goedemiddag" a correct translation of "Good day", which is undesirable. The solution is to have two concepts, one for "good afternoon" and one for "good day". Both concepts get the Finnish labels "Hyvää päivää" and "Päivää". The Finnish labels for the "good afternoon" concept get a note that Toisto shows when asking for the Dutch or English translation of "Hyvää päivää" or "Päivää" so that the user knows the context. The note is the part after the semicolon (`;`).
 
 In the topic file this looks as follows:
 
@@ -313,9 +313,9 @@ The format of the JSON files is as follows:
 }
 ```
 
-Note that because the second person singular and plural are the same in English, Toisto needs to tell the user whether it is asking for a translation of the singular version or the plural version of "You are". The hint is the part after the semicolon (`;`).
+Note that because the second person singular and plural are the same in English, Toisto needs to tell the user whether it is asking for a translation of the singular version or the plural version of "You are". The note is the part after the semicolon (`;`).
 
-The third person in Finnish also needs a hint. Because Finnish does not distinguish between male and female gender, Toisto needs to tell the user whether it is asking for the female or the male translation of "Hänellä on".
+The third person in Finnish also needs a note. Because Finnish does not distinguish between male and female gender, Toisto needs to tell the user whether it is asking for the female or the male translation of "Hänellä on".
 
 ### Infinitive
 

--- a/src/toisto/model/language/label.py
+++ b/src/toisto/model/language/label.py
@@ -8,12 +8,12 @@ from typing import Final
 class Label(str):
     """Class representing labels for concepts."""
 
-    HINT_SEP: Final = ";"
+    NOTE_SEP: Final = ";"
     SPELLING_ALTERNATIVES_SEP: Final = "|"
 
     def __eq__(self, other: object) -> bool:
-        """Ignore hints when determining equality."""
-        return self.without_hint == Label(other).without_hint
+        """Ignore notes when determining equality."""
+        return self.without_note == Label(other).without_note
 
     def __ne__(self, other: object) -> bool:
         """Return whether the labels are not equal."""
@@ -22,17 +22,17 @@ class Label(str):
     @property
     def spelling_alternatives(self) -> Labels:
         """Extract the spelling alternatives from the label."""
-        return label_factory(self.without_hint.split(self.SPELLING_ALTERNATIVES_SEP))
+        return label_factory(self.without_note.split(self.SPELLING_ALTERNATIVES_SEP))
 
     @property
-    def hint(self) -> str:
-        """Return the label hint, if any."""
-        return self.split(self.HINT_SEP)[1] if self.HINT_SEP in self else ""
+    def note(self) -> str:
+        """Return the label note, if any."""
+        return self.split(self.NOTE_SEP)[1] if self.NOTE_SEP in self else ""
 
     @property
-    def without_hint(self) -> str:
-        """Return the label without the hint."""
-        return self.split(self.HINT_SEP)[0]
+    def without_note(self) -> str:
+        """Return the label without the note."""
+        return self.split(self.NOTE_SEP)[0]
 
 
 Labels = tuple[Label, ...]

--- a/src/toisto/model/quiz/quiz.py
+++ b/src/toisto/model/quiz/quiz.py
@@ -144,16 +144,16 @@ class Quiz:
         else:
             quiz_type = cast(Literal[TranslationQuizType, ListenQuizType, SemanticQuizType], self.quiz_types[0])
             instruction_text = INSTRUCTIONS[quiz_type]
-        return f"{instruction_text} {ALL_LANGUAGES[self.answer_language]}{self._instruction_hint()}"
+        return f"{instruction_text} {ALL_LANGUAGES[self.answer_language]}{self._instruction_note()}"
 
     def is_blocked_by(self, quizzes: Quizzes) -> bool:
         """Return whether this quiz should come after any of the given quizzes."""
         return bool(Quizzes(self.blocked_by) & quizzes)
 
-    def _instruction_hint(self) -> str:
-        """Return the instruction hint, if applicable."""
-        hint_applicable = self.question_language != self.answer_language or "answer" in self.quiz_types
-        return f" ({hint})" if hint_applicable and (hint := self._question.hint) else ""
+    def _instruction_note(self) -> str:
+        """Return the instruction note, if applicable."""
+        note_applicable = self.question_language != self.answer_language or "answer" in self.quiz_types
+        return f" ({note})" if note_applicable and (note := self._question.note) else ""
 
 
 class Quizzes(set[Quiz]):

--- a/tests/toisto/model/quiz/test_quiz.py
+++ b/tests/toisto/model/quiz/test_quiz.py
@@ -40,12 +40,12 @@ class QuizTest(QuizTestCase):
 
     def test_other_answers(self):
         """Test that the other answers can be retrieved."""
-        quiz = self.create_quiz(self.concept, "fi", "nl", "Yksi", ["Een", "Eén;hint should be ignored"])
+        quiz = self.create_quiz(self.concept, "fi", "nl", "Yksi", ["Een", "Eén;note should be ignored"])
         self.assertEqual(["Eén"], [str(answer) for answer in quiz.other_answers("Een")])
 
     def test_no_other_answers_when_quiz_type_is_listen(self):
         """Test that the other answers are not returned if the zuiz type is listen."""
-        quiz = self.create_quiz(self.concept, "fi", "nl", "Yksi", ["Een", "Eén;hint should be ignored"], "listen")
+        quiz = self.create_quiz(self.concept, "fi", "nl", "Yksi", ["Een", "Eén;note should be ignored"], "listen")
         self.assertEqual((), quiz.other_answers("Een"))
 
     def test_spelling_alternative_of_answer(self):
@@ -105,23 +105,23 @@ class QuizTest(QuizTestCase):
             quiz = self.create_quiz(self.concept, "fi", "fi", "Hei", ["Hei hei"], (quiz_type,))
             self.assertEqual(expected_instruction + " Finnish", quiz.instruction())
 
-    def test_instruction_with_hint(self):
-        """Test that the question hint is added to the instruction."""
+    def test_instruction_with_note(self):
+        """Test that the question note is added to the instruction."""
         quiz = self.create_quiz(self.concept, "en", "nl", "You are;singular", ["Jij bent|Je bent"])
         self.assertEqual("Translate into Dutch (singular)", quiz.instruction())
 
-    def test_question_hint(self):
-        """Test that a hint can be added to the question."""
+    def test_question_note(self):
+        """Test that a note can be added to the question."""
         quiz = self.create_quiz(self.concept, "en", "nl", "You are;singular", ["Jij bent|Je bent"])
         self.assertEqual("You are", quiz.question)
 
-    def test_question_hint_is_not_shown_when_question_and_answer_language_are_the_same(self):
-        """Test that a hint is not shown when the question and answer languages are the same."""
+    def test_question_note_is_not_shown_when_question_and_answer_language_are_the_same(self):
+        """Test that a note is not shown when the question and answer languages are the same."""
         quiz = self.create_quiz(self.concept, "fi", "fi", "Hän on;female", ["He ovat"], "pluralize")
         self.assertEqual("Give the [underline]plural[/underline] in Finnish", quiz.instruction())
 
-    def test_question_hint_is_ignored_in_answer(self):
-        """Test that a hint can be added to the question."""
+    def test_question_note_is_ignored_in_answer(self):
+        """Test that a note can be added to the question."""
         quiz = self.create_quiz(self.concept, "nl", "en", "Jij bent", ["You are;singular"])
         self.assertEqual("You are", quiz.answer)
         self.assertEqual(("You are",), quiz.answers)
@@ -135,10 +135,10 @@ class QuizEqualityTests(QuizTestCase):
         self.assertEqual(self.quiz, self.quiz)
         self.assertEqual(self.copy_quiz(self.quiz), self.quiz)
 
-    def test_equal_with_different_hints(self):
-        """Test that quizzes are equal if only their hints differ."""
-        self.assertEqual(self.copy_quiz(self.quiz, question="Englanti;hint"), self.quiz)
-        self.assertEqual(self.copy_quiz(self.quiz, answers=["Engels;hint"]), self.quiz)
+    def test_equal_with_different_notes(self):
+        """Test that quizzes are equal if only their notes differ."""
+        self.assertEqual(self.copy_quiz(self.quiz, question="Englanti;note"), self.quiz)
+        self.assertEqual(self.copy_quiz(self.quiz, answers=["Engels;note"]), self.quiz)
 
     def test_not_equal_with_different_languages(self):
         """Test that quizzes are not equal if only their languages differ."""


### PR DESCRIPTION
… as part of quiz instructions is no longer called a hint but a note. This prepares for supporting notes that are shown after the quiz.