### PR TITLE
When quizzing a translatiion show notes of the target language only.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - Add question/answer concepts. Closes [#233](https://github.com/fniessink/toisto/issues/233).
 - Concepts can belong to multiple topics. Closes [#234](https://github.com/fniessink/toisto/issues/234).
+- Allow for adding notes that are shown after a quiz has been answered. Closes [#321](https://github.com/fniessink/toisto/issues/321).
 - Added several topics and concepts.
 
 ### Changed

--- a/src/toisto/model/quiz/quiz.py
+++ b/src/toisto/model/quiz/quiz.py
@@ -149,7 +149,7 @@ class Quiz:
     @property
     def notes(self) -> Sequence[str]:
         """Return the quiz notes."""
-        return self._question.notes
+        return self._answers[0].notes if "write" in self.quiz_types else self._question.notes
 
     def is_blocked_by(self, quizzes: Quizzes) -> bool:
         """Return whether this quiz should come after any of the given quizzes."""

--- a/tests/toisto/model/quiz/test_quiz_factory.py
+++ b/tests/toisto/model/quiz/test_quiz_factory.py
@@ -835,3 +835,19 @@ class DiminutiveTest(ToistoTestCase):
             },
             create_quizzes("nl", "en", concept),
         )
+
+
+class QuizNoteTest(ToistoTestCase):
+    """Unit tests for the quiz notes."""
+
+    def test_note(self):
+        """Test that the quizzes use the notes of the target language."""
+        concept = create_concept(
+            "finnish",
+            dict(
+                fi="suomi;;In Finnish, the names of languages are not capitalized",
+                nl="Fins;;In Dutch, the names of languages are capitalized",
+            ),
+        )
+        for quiz in create_quizzes("fi", "nl", concept):
+            self.assertEqual("In Finnish, the names of languages are not capitalized", quiz.notes[-1])


### PR DESCRIPTION
Closes #340.