### PR TITLE
Give an error message when the user's filters (by level, by topic, by…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Fixed
+
+- Give an error message when the user's filters (by level, by topic, by concept identifier) don't match any concepts. Fixes [#437](https://github.com/fniessink/toisto/issues/437).
+
 ### Added
 
 - Added several topics and concepts.

--- a/src/toisto/app.py
+++ b/src/toisto/app.py
@@ -34,7 +34,7 @@ def main() -> None:
     extra_concept_files = [Path(concept_file) for concept_file in args.concept_file]
     concepts |= load_concepts(extra_concept_files, registry, argument_parser)
     selected_topics = (args.topic or TOPICS) + [Topic(filepath.stem) for filepath in extra_concept_files]
-    concepts = filter_concepts(concepts, args.concept, args.levels, selected_topics)
+    concepts = filter_concepts(concepts, args.concept, args.levels, selected_topics, argument_parser)
     quizzes = create_quizzes(args.target_language, args.source_language, *concepts)
     progress = load_progress(args.target_language, argument_parser)
     match args.command:

--- a/src/toisto/model/language/concept.py
+++ b/src/toisto/model/language/concept.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
+from argparse import ArgumentParser
 from collections.abc import Generator, Iterable
 from dataclasses import dataclass
 from functools import cached_property
 from itertools import chain
-from typing import ClassVar, NewType, cast, get_args
+from typing import ClassVar, NewType, NoReturn, cast, get_args
 
 from . import Language
 from .cefr import CommonReferenceLevel
@@ -162,14 +163,17 @@ def topics(concepts: Iterable[Concept]) -> list[Topic]:
 def filter_concepts(
     concepts: set[Concept],
     selected_concepts: list[ConceptId],
-    levels: list[CommonReferenceLevel],
-    topics: list[Topic],
-) -> set[Concept]:
+    selected_levels: list[CommonReferenceLevel],
+    selected_topics: list[Topic],
+    argument_parser: ArgumentParser,
+) -> set[Concept] | NoReturn:
     """Filter the concepts by selected concepts, levels, and topics."""
     if selected_concepts:
         concepts = {concept for concept in concepts if concept.concept_id in selected_concepts}
-    if levels:
-        concepts = {concept for concept in concepts if concept.level in levels}
-    if topics:
-        concepts = {concept for concept in concepts if concept.topics & set(topics)}
+    if selected_levels:
+        concepts = {concept for concept in concepts if concept.level in selected_levels}
+    if selected_topics:
+        concepts = {concept for concept in concepts if concept.topics & set(selected_topics)}
+    if (selected_concepts or selected_levels or selected_topics) and not concepts:
+        argument_parser.error("No concepts found that match your selection criteria\n")
     return concepts

--- a/tests/toisto/model/language/test_concept.py
+++ b/tests/toisto/model/language/test_concept.py
@@ -1,7 +1,9 @@
 """Unit tests for concepts."""
 
 import unittest
+from argparse import ArgumentParser
 from typing import cast
+from unittest.mock import Mock, patch
 
 from toisto.model.language.concept import Concept, ConceptId, Topic, filter_concepts
 from toisto.model.language.concept_factory import ConceptDict, create_concept
@@ -83,16 +85,22 @@ class ConceptFilterTest(unittest.TestCase):
 
     def test_no_filter(self):
         """Test that all concepts are returned when there is no filter specified."""
-        self.assertEqual({self.two}, filter_concepts({self.two}, [], [], []))
+        self.assertEqual({self.two}, filter_concepts({self.two}, [], [], [], ArgumentParser()))
 
     def test_filter_by_selected_concepts(self):
         """Test that concepts can be filtered by selected concepts."""
-        self.assertEqual({self.two}, filter_concepts({self.two, self.three}, ["two"], [], []))
+        self.assertEqual({self.two}, filter_concepts({self.two, self.three}, ["two"], [], [], ArgumentParser()))
 
     def test_filter_by_level(self):
         """Test that concepts can be filtered by level."""
-        self.assertEqual({self.two}, filter_concepts({self.two, self.three}, [], ["A1"], []))
+        self.assertEqual({self.two}, filter_concepts({self.two, self.three}, [], ["A1"], [], ArgumentParser()))
 
     def test_filter_by_topic(self):
         """Test that concepts can be filtered by topic."""
-        self.assertEqual({self.two}, filter_concepts({self.two, self.three}, [], [], ["small"]))
+        self.assertEqual({self.two}, filter_concepts({self.two, self.three}, [], [], ["small"], ArgumentParser()))
+
+    @patch("sys.stderr.write")
+    def test_no_match(self, sys_stderr_write: Mock):
+        """Test that an error message is given when no concepts match the filter criteria."""
+        self.assertRaises(SystemExit, filter_concepts, {self.two, self.three}, [], [], ["missing"], ArgumentParser())
+        self.assertIn("No concepts found that match your selection criteria", sys_stderr_write.call_args_list[1][0][0])


### PR DESCRIPTION
… concept identifier) don't match any concepts. Fixes #437.