### PR TITLE
Toisto wouldn't warn the user when answering in the wrong language in…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to Toisto will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Toisto wouldn't warn the user when answering in the wrong language in the case of dictation quizzes.
+
+### Changed
+
+- Make the warning for answering in the wrong language more prominent.
+
 ## 0.13.0 - 2023-11-12
 
 ### Fixed

--- a/src/toisto/model/quiz/quiz.py
+++ b/src/toisto/model/quiz/quiz.py
@@ -119,7 +119,7 @@ class Quiz:
 
     def is_question(self, guess: Label) -> bool:
         """Return whether the guess is not the answer, but the question (common user error with listening quizzes)."""
-        return match(guess, *self._question.spelling_alternatives)
+        return any(match(guess, *label.spelling_alternatives) for label in (self._question, *self._question_meanings))
 
     @cached_property
     def question(self) -> Label:

--- a/src/toisto/ui/text.py
+++ b/src/toisto/ui/text.py
@@ -50,7 +50,7 @@ DONE: Final = f"""👍 Good job. You're done for now. Please come back later or 
 
 TRY_AGAIN: Final = "⚠️  Incorrect. Please try again."
 
-TRY_AGAIN_IN_ANSWER_LANGUAGE: Final = "⚠️  Incorrect. Please try again, in [bold]%(language)s[/bold]."
+TRY_AGAIN_IN_ANSWER_LANGUAGE: Final = "⚠️  Incorrect. Please try again, in [yellow][bold]%(language)s[/bold][/yellow]."
 
 CORRECT: Final = "✅ Correct.\n"
 

--- a/tests/toisto/command/test_practice.py
+++ b/tests/toisto/command/test_practice.py
@@ -66,6 +66,13 @@ class PracticeTest(ToistoTestCase):
         patched_print = self.practice(self.quizzes)
         self.assertIn(call(TRY_AGAIN_IN_ANSWER_LANGUAGE % dict(language="Dutch")), patched_print.call_args_list)
 
+    @patch("builtins.input", Mock(return_value="Hoi\n"))
+    def test_answer_with_question_listen_quiz(self):
+        """Test that the language to answer is stressed, when the user answers the quiz with the wrong language."""
+        quizzes = create_quizzes(Language("fi"), Language("nl"), self.concept).by_quiz_type("dictate")
+        patched_print = self.practice(quizzes)
+        self.assertIn(call(TRY_AGAIN_IN_ANSWER_LANGUAGE % dict(language="Finnish")), patched_print.call_args_list)
+
     @patch("builtins.input", Mock(side_effect=["\n", "Hoi\n"]))
     @patch("builtins.print")
     def test_quiz_empty_answer(self, mock_print: Mock):


### PR DESCRIPTION
… the case of dictation quizzes. Make the warning for answering in the wrong language more prominent.