### PR TITLE
Use identifier registry when loading topics to check for duplilicated…

### DIFF
--- a/src/toisto/app.py
+++ b/src/toisto/app.py
@@ -26,7 +26,7 @@ from .persistence.concepts import ConceptIdRegistry, load_concepts
 from .persistence.config import default_config, read_config
 from .persistence.progress import load_progress
 from .persistence.spelling_alternatives import load_spelling_alternatives
-from .persistence.topics import load_topics
+from .persistence.topics import TopicIdRegistry, load_topics
 from .ui.cli import create_argument_parser, parse_arguments
 from .ui.text import console, show_welcome
 
@@ -35,16 +35,17 @@ def init() -> tuple[ConfigParser, Namespace, set[Concept], set[Topic], Quizzes, 
     """Initialize the main program."""
     argument_parser = create_argument_parser(default_config())
     config = read_config(argument_parser)
-    registry = ConceptIdRegistry(argument_parser)
-    concepts = load_concepts(CONCEPT_JSON_FILES, registry, argument_parser)
-    topics = load_topics(TOPIC_FILES, argument_parser)
+    concept_registry = ConceptIdRegistry(argument_parser)
+    concepts = load_concepts(CONCEPT_JSON_FILES, concept_registry, argument_parser)
+    topic_registry = TopicIdRegistry(argument_parser)
+    topics = load_topics(TOPIC_FILES, topic_registry, argument_parser)
     argument_parser = create_argument_parser(config, concepts, topics)
     args = parse_arguments(argument_parser)
     load_spelling_alternatives(args.target_language, args.source_language)
     extra_concept_files = [Path(concept_file) for concept_file in args.concept_file]
-    concepts |= load_concepts(extra_concept_files, registry, argument_parser)
+    concepts |= load_concepts(extra_concept_files, concept_registry, argument_parser)
     extra_topic_files = [Path(topic_file) for topic_file in args.topic_file]
-    topics |= load_topics(extra_topic_files, argument_parser)
+    topics |= load_topics(extra_topic_files, topic_registry, argument_parser)
     concepts = filter_concepts(concepts, topics, args.concept, args.topic, argument_parser)
     quizzes = create_quizzes(args.target_language, args.source_language, *concepts)
     progress = load_progress(args.target_language, argument_parser)

--- a/src/toisto/persistence/topics.py
+++ b/src/toisto/persistence/topics.py
@@ -7,7 +7,15 @@ from typing import NoReturn, TypedDict, cast
 from ..metadata import NAME
 from ..model.language.concept import ConceptId
 from ..model.topic.topic import Topic
+from .identifier_registry import IdentifierRegistry
 from .json_file import load_json
+
+
+class TopicIdRegistry(IdentifierRegistry[str]):
+    """Registry to check the uniqueness of topic identifiers across topic files."""
+
+    def _identifier_name(self) -> str:
+        return "topic"
 
 
 class TopicJSON(TypedDict):
@@ -18,15 +26,17 @@ class TopicJSON(TypedDict):
     topics: list[str]
 
 
-def load_topics(topic_files: list[Path], argument_parser: ArgumentParser) -> set[Topic] | NoReturn:
+def load_topics(
+    topic_files: list[Path], topic_id_registry: TopicIdRegistry, argument_parser: ArgumentParser
+) -> set[Topic] | NoReturn:
     """Load the topics from the specified topic files."""
     topics = set()
     try:
         for topic_file in topic_files:
             topic_json = cast(TopicJSON, load_json(topic_file))
-            topics.add(
-                Topic(topic_json["name"], frozenset(topic_json["concepts"]), frozenset(topic_json.get("topics", []))),
-            )
+            name = topic_json["name"]
+            topic_id_registry.check_and_register_identifiers((name,), topic_file)
+            topics.add(Topic(name, frozenset(topic_json["concepts"]), frozenset(topic_json.get("topics", []))))
     except Exception as reason:  # noqa: BLE001
         argument_parser.error(f"{NAME} cannot read topic file {topic_file}: {reason}.\n")
     return topics

--- a/tests/concepts/test_topics.py
+++ b/tests/concepts/test_topics.py
@@ -4,7 +4,7 @@ from argparse import ArgumentParser
 
 from toisto.metadata import CONCEPT_JSON_FILES, TOPIC_FILES
 from toisto.persistence.concepts import ConceptIdRegistry, load_concepts
-from toisto.persistence.topics import load_topics
+from toisto.persistence.topics import TopicIdRegistry, load_topics
 
 from ..base import ToistoTestCase
 
@@ -17,7 +17,7 @@ class TopicsTest(ToistoTestCase):
         argument_parser = ArgumentParser()
         self.concepts = load_concepts(CONCEPT_JSON_FILES, ConceptIdRegistry(argument_parser), argument_parser)
         self.all_concept_ids = {concept.concept_id for concept in self.concepts}
-        self.topics = load_topics(TOPIC_FILES, argument_parser)
+        self.topics = load_topics(TOPIC_FILES, TopicIdRegistry(argument_parser), argument_parser)
 
     def test_all_concepts_have_at_least_one_topic(self):
         """Test that all concepts have at least one topic."""

--- a/tests/toisto/persistence/test_topics.py
+++ b/tests/toisto/persistence/test_topics.py
@@ -6,7 +6,7 @@ from unittest.mock import Mock, patch
 
 from toisto.model.language.concept import ConceptId
 from toisto.model.topic.topic import Topic
-from toisto.persistence.topics import load_topics
+from toisto.persistence.topics import TopicIdRegistry, load_topics
 
 from ...base import ToistoTestCase
 
@@ -17,12 +17,19 @@ class LoadTopicsTest(ToistoTestCase):
     def setUp(self) -> None:
         """Set up the test fixtures."""
         self.argument_parser = ArgumentParser()
+        self.topic_id_registry = TopicIdRegistry(self.argument_parser)
 
     @patch("pathlib.Path.exists", Mock(return_value=False))
     @patch("sys.stderr.write")
     def test_load_topics_from_non_existing_file(self, stderr_write: Mock):
         """Test that an error message is given when the topic file does not exist."""
-        self.assertRaises(SystemExit, load_topics, [Path("file-doesnt-exist")], self.argument_parser)
+        self.assertRaises(
+            SystemExit,
+            load_topics,
+            [Path("file-doesnt-exist")],
+            self.topic_id_registry,
+            self.argument_parser,
+        )
         self.assertIn(
             "cannot read topic file file-doesnt-exist: [Errno 2] No such file or directory: 'file-doesnt-exist'.\n",
             stderr_write.call_args_list[1][0][0],
@@ -35,7 +42,7 @@ class LoadTopicsTest(ToistoTestCase):
         path_open.return_value.__enter__.return_value.read.return_value = '{"name": "topic", "concepts": ["to be"]}'
         self.assertSetEqual(
             {Topic("topic", frozenset([ConceptId("to be")]))},
-            load_topics([Path("filename")], self.argument_parser),
+            load_topics([Path("filename")], self.topic_id_registry, self.argument_parser),
         )
 
     @patch("pathlib.Path.exists", Mock(return_value=True))
@@ -46,5 +53,25 @@ class LoadTopicsTest(ToistoTestCase):
         path_open.return_value.__enter__.return_value.read.return_value = topic_json
         self.assertSetEqual(
             {Topic("topic", frozenset([ConceptId("to be")]), frozenset(["other"]))},
-            load_topics([Path("filename")], self.argument_parser),
+            load_topics([Path("filename")], self.topic_id_registry, self.argument_parser),
+        )
+
+    @patch("pathlib.Path.exists", Mock(return_value=True))
+    @patch("pathlib.Path.open")
+    @patch("sys.stderr.write")
+    def test_load_topic_with_same_topic_id(self, stderr_write: Mock, path_open: Mock):
+        """Test that an error message is given when a concept file contains the same concept id as another file."""
+        path_open.return_value.__enter__.return_value.read.return_value = '{"name": "topic", "concepts": ["to be"]}'
+        load_topics([Path("filename")], self.topic_id_registry, self.argument_parser)
+        self.assertRaises(
+            SystemExit,
+            load_topics,
+            [Path("filename")],
+            self.topic_id_registry,
+            self.argument_parser,
+        )
+        self.assertIn(
+            f"Toisto cannot read topic file {Path('filename')}: topic identifier 'topic' occurs multiple times in "
+            f"topic file {Path('filename')}.\n",
+            stderr_write.call_args_list[1][0][0],
         )


### PR DESCRIPTION
… topic names.