### PR TITLE
Fix crash due to missing root concepts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
-- Don't show builtin spelling alternatives as other correct answers. For example, Toisto would show "de pijn" as another correct answer when a user with Dutch as source language had entered "pijn" as answer. Closes [#623](https://github.com/fniessink/toisto/issues/623).
+- Don't show builtin spelling alternatives as other correct answers. For example, Toisto would show "de pijn" as another correct answer when a user with Dutch as source language had entered "pijn" as answer. Fixes [#623](https://github.com/fniessink/toisto/issues/623).
+- When practicing Dutch, Toisto would crash on certain concepts because they would refer to non-existing root concepts. Fixes [#626](https://github.com/fniessink/toisto/issues/626).
 
 ### Added
 

--- a/src/concepts/adpositions.json
+++ b/src/concepts/adpositions.json
@@ -120,7 +120,6 @@
             ],
             "nl": [
                 "table",
-                "to stand",
                 "in the middle",
                 "room"
             ],
@@ -175,7 +174,6 @@
             ],
             "nl": [
                 "lamp",
-                "to stand",
                 "on top of"
             ],
             "fi": [
@@ -211,7 +209,6 @@
             ],
             "nl": [
                 "glass",
-                "to stand",
                 "below",
                 "table"
             ],

--- a/src/concepts/mixed/food.json
+++ b/src/concepts/mixed/food.json
@@ -450,7 +450,7 @@
         "roots": {
             "en": [
                 "hot",
-                "chocoloate"
+                "chocolate"
             ],
             "nl": [
                 "chocolate",

--- a/src/concepts/nature.json
+++ b/src/concepts/nature.json
@@ -363,15 +363,9 @@
     },
     "northern lights": {
         "roots": {
-            "en": [
-                "north",
-                "light"
-            ],
+            "en": "north",
             "fi": "fire",
-            "nl": [
-                "north",
-                "light"
-            ]
+            "nl": "north"
         },
         "en": "northern lights",
         "fi": "revontulet",

--- a/src/concepts/work.json
+++ b/src/concepts/work.json
@@ -165,15 +165,9 @@
     "part-time job": {
         "hypernym": "job",
         "roots": {
-            "en": [
-                "job"
-            ],
-            "fi": [
-                "work"
-            ],
-            "nl": [
-                "werk"
-            ]
+            "en": "job",
+            "fi": "work",
+            "nl": "work"
         },
         "en": "part-time job",
         "fi": "osa-aikatyö",

--- a/tests/concepts/test_concepts.py
+++ b/tests/concepts/test_concepts.py
@@ -28,8 +28,9 @@ class ConceptsTest(ToistoTestCase):
     def test_roots_exist(self):
         """Test that all roots use existing concept ids."""
         for concept in self.concepts:
-            for root in concept.roots(self.fi):
-                self.assertIn(root, Concept.instances.get_values(root.concept_id))
+            for language in BUILT_IN_LANGUAGES:
+                for root in concept.roots(language):
+                    self.assertIn(root, Concept.instances.get_values(root.concept_id))
 
     def test_examples_exist(self):
         """Test that all examples use existing concept ids."""


### PR DESCRIPTION
When practicing Dutch, Toisto would crash on certain concepts because they would refer to non-existing root concepts.

Fixes #626.