### PR TITLE
Change --concept into positional argument.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Toisto will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- On the command line, accept concepts as positional arguments, so users don't have to type `--concept` or `-c` before each concept. Closes [#631](https://github.com/fniessink/toisto/issues/631).
+
 ## 0.17.0 - 2024-04-01
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -102,7 +102,13 @@ $ toisto practice --target fi --source en
 To practice a specific concept and related concepts, pass it as follows:
 
 ```console
-$ toisto practice --target fi -source en --concept color
+$ toisto practice --target fi --source en color
+```
+
+It's also possible to specify more than one concept to practice:
+
+```console
+$ toisto practice --target fi --source en fruit vegetable
 ```
 
 Add `--help` or `-h` to get more information about the command-line options and arguments:

--- a/docs/software.md
+++ b/docs/software.md
@@ -701,7 +701,7 @@ If a concept has more than one antonym (for example, "large" and "big" are both 
 > [!NOTE]
 > Concept X is a hypernym of concept Y if concept Y is a (kind of) X. For example, red is a color, so the concept "color" is a hypernym of the concept "red". The reverse relation is called hyponym, so "red" is a hyponym of "color".
 
-When one concept is a hypernym of another concept (and conversely the other concept is a hyponym of the first concept), this can be specified with the `hypernym` relation. Toisto will derive the hyponym relations automatically. Toisto uses the hypernym and hyponym relations to decide which related concepts to use when a user selects a concept to practice. Given the JSON below, the command `toisto practice --concept color`, would select both color and red to practice.
+When one concept is a hypernym of another concept (and conversely the other concept is a hyponym of the first concept), this can be specified with the `hypernym` relation. Toisto will derive the hyponym relations automatically. Toisto uses the hypernym and hyponym relations to decide which related concepts to use when a user selects a concept to practice. Given the JSON below, the command `toisto practice color`, would select both color and red to practice.
 
 ```json
 {
@@ -724,7 +724,7 @@ If a concept has more than one hypernym (for example, "pet" and "mammal" are bot
 > [!NOTE]
 > Concept X is a holonym of concept Y if concept Y is a part of X. For example, cars have wheels, so the concept "car" is a holonym of the concept "wheel". The reverse relation is called meronym, so "wheel" is a meronym of "car".
 
-When one concept is a holonym of another concept (and conversely the other concept is a meronym of the first concept), this can be specified with the `holonym` relation. Toisto will derive the meronym relations automatically. Toisto uses the holonym and meronym relations to decide which related concepts to use when a user selects a concept to practice. Given the JSON below, the command `toisto practice --concept car`, would select both the concept "car" and the concept "wheel" to practice.
+When one concept is a holonym of another concept (and conversely the other concept is a meronym of the first concept), this can be specified with the `holonym` relation. Toisto will derive the meronym relations automatically. Toisto uses the holonym and meronym relations to decide which related concepts to use when a user selects a concept to practice. Given the JSON below, the command `toisto practice car`, would select both the concept "car" and the concept "wheel" to practice.
 
 ```json
 {
@@ -744,7 +744,7 @@ If a concept has more than one holonym (for example, "chair" and "table" are bot
 
 ### Concept involvement
 
-When one concept involves another concept, this can be specified with the `involves` relation. Toisto will derive the inverse relation automatically. Toisto uses the involvement relations to decide with related concepts to use when a user selects a concept to practice. Given the JSON below, the command `toisto practice --concept "to paint"`, would select "to paint", "painter", and "painting" to practice.
+When one concept involves another concept, this can be specified with the `involves` relation. Toisto will derive the inverse relation automatically. Toisto uses the involvement relations to decide with related concepts to use when a user selects a concept to practice. Given the JSON below, the command `toisto practice "to paint"`, would select "to paint", "painter", and "painting" to practice.
 
 ```json
 {

--- a/src/toisto/app.py
+++ b/src/toisto/app.py
@@ -31,7 +31,7 @@ def init() -> tuple[ConfigParser, Namespace, Progress]:
     args = parse_arguments(argument_parser)
     load_spelling_alternatives(args.target_language, args.source_language)
     concepts |= loader.load(*args.file)
-    concepts = filter_concepts(concepts, args.concept, args.target_language, argument_parser)
+    concepts = filter_concepts(concepts, args.concepts, args.target_language, argument_parser)
     quizzes = create_quizzes(args.target_language, args.source_language, *concepts)
     progress = load_progress(args.target_language, quizzes, argument_parser)
     return config, args, progress

--- a/src/toisto/ui/cli.py
+++ b/src/toisto/ui/cli.py
@@ -40,16 +40,13 @@ def check_language(language: str) -> str:
     raise ArgumentTypeError(message)
 
 
-def add_selection_arguments(parser: ArgumentParser, concepts: set[Concept]) -> None:
-    """Add the selection arguments."""
-    selection_group = parser.add_mutually_exclusive_group()
+def add_concept_argument(parser: ArgumentParser, concepts: set[Concept]) -> None:
+    """Add the concept argument."""
     concept_ids = sorted(concept.concept_id for concept in concepts)
-    selection_group.add_argument(
-        "-c",
-        "--concept",
-        action="append",
-        default=[],
+    parser.add_argument(
+        "concepts",
         metavar="{concept}",
+        nargs="*",
         help=f"concept to use, can be repeated; default: all; built-in concepts: {', '.join(concept_ids)}",
     )
 
@@ -90,8 +87,8 @@ class CommandBuilder:
             formatter_class=RichHelpFormatter,
         )
         add_language_arguments(parser, self.config)
-        add_selection_arguments(parser, self.concepts)
         add_file_arguments(parser)
+        add_concept_argument(parser, self.concepts)
         return parser
 
     def add_practice_command(self) -> None:

--- a/tests/toisto/ui/test_cli.py
+++ b/tests/toisto/ui/test_cli.py
@@ -36,7 +36,6 @@ class ParserTest(unittest.TestCase):
     def test_help(self, sys_stdout_write: Mock) -> None:
         """Test that the help message is displayed."""
         self.assertRaises(SystemExit, parse_arguments, self.argument_parser())
-        self.maxDiff = None
         self.assertEqual(
             """Usage: toisto [-h] [-V] {practice,progress} ...
 
@@ -65,7 +64,7 @@ See https://github.com/fniessink/toisto/blob/main/README.md for more information
             command="practice",
             target_language="nl",
             source_language="fi",
-            concept=[],
+            concepts=[],
             file=[],
         )
         self.assertEqual(expected_namespace, parse_arguments(self.argument_parser()))
@@ -83,9 +82,12 @@ See https://github.com/fniessink/toisto/blob/main/README.md for more information
         }
         self.assertRaises(SystemExit, parse_arguments, self.argument_parser(concepts=concepts))
         self.assertEqual(
-            """Usage: toisto practice [-h] -t {language} -s {language} [-c {concept}] [-f {file}]
+            """Usage: toisto practice [-h] -t {language} -s {language} [-f {file}] [{concept} ...]
 
 Practice a language.
+
+Positional Arguments:
+  {concept}             concept to use, can be repeated; default: all; built-in concepts: bar, foo
 
 Options:
   -h, --help            show this help message and exit
@@ -93,8 +95,6 @@ Options:
                         target language; languages available in built-in concepts: en, fi, nl
   -s, --source {language}
                         source language; languages available in built-in concepts: en, fi, nl
-  -c, --concept {concept}
-                        concept to use, can be repeated; default: all; built-in concepts: bar, foo
   -f, --file {file}     file with extra concepts to read, can be repeated
 """,
             self.ANSI_ESCAPE_CODES.sub("", sys_stdout_write.call_args_list[2][0][0]),
@@ -109,9 +109,12 @@ Options:
         config_parser.set("languages", "target", "fi")
         self.assertRaises(SystemExit, parse_arguments, self.argument_parser(config_parser))
         self.assertEqual(
-            """Usage: toisto practice [-h] [-t {language}] -s {language} [-c {concept}] [-f {file}]
+            """Usage: toisto practice [-h] [-t {language}] -s {language} [-f {file}] [{concept} ...]
 
 Practice a language.
+
+Positional Arguments:
+  {concept}             concept to use, can be repeated; default: all; built-in concepts:
 
 Options:
   -h, --help            show this help message and exit
@@ -119,8 +122,6 @@ Options:
                         target language; default: fi; languages available in built-in concepts: en, fi, nl
   -s, --source {language}
                         source language; languages available in built-in concepts: en, fi, nl
-  -c, --concept {concept}
-                        concept to use, can be repeated; default: all; built-in concepts:
   -f, --file {file}     file with extra concepts to read, can be repeated
 """,
             self.ANSI_ESCAPE_CODES.sub("", sys_stdout_write.call_args_list[2][0][0]),
@@ -135,9 +136,12 @@ Options:
         config_parser.set("languages", "levels", "A1 A2")
         self.assertRaises(SystemExit, parse_arguments, self.argument_parser(config_parser))
         self.assertEqual(
-            """Usage: toisto practice [-h] -t {language} -s {language} [-c {concept}] [-f {file}]
+            """Usage: toisto practice [-h] -t {language} -s {language} [-f {file}] [{concept} ...]
 
 Practice a language.
+
+Positional Arguments:
+  {concept}             concept to use, can be repeated; default: all; built-in concepts:
 
 Options:
   -h, --help            show this help message and exit
@@ -145,8 +149,6 @@ Options:
                         target language; languages available in built-in concepts: en, fi, nl
   -s, --source {language}
                         source language; languages available in built-in concepts: en, fi, nl
-  -c, --concept {concept}
-                        concept to use, can be repeated; default: all; built-in concepts:
   -f, --file {file}     file with extra concepts to read, can be repeated
 """,
             self.ANSI_ESCAPE_CODES.sub("", sys_stdout_write.call_args_list[2][0][0]),
@@ -158,10 +160,12 @@ Options:
         """Test that the progress help message is displayed."""
         self.assertRaises(SystemExit, parse_arguments, self.argument_parser())
         self.assertEqual(
-            """Usage: toisto progress [-h] -t {language} -s {language} [-c {concept}] [-f {file}] \
-[-S {option}]
+            """Usage: toisto progress [-h] -t {language} -s {language} [-f {file}] [-S {option}] [{concept} ...]
 
 Show progress.
+
+Positional Arguments:
+  {concept}             concept to use, can be repeated; default: all; built-in concepts:
 
 Options:
   -h, --help            show this help message and exit
@@ -169,8 +173,6 @@ Options:
                         target language; languages available in built-in concepts: en, fi, nl
   -s, --source {language}
                         source language; languages available in built-in concepts: en, fi, nl
-  -c, --concept {concept}
-                        concept to use, can be repeated; default: all; built-in concepts:
   -f, --file {file}     file with extra concepts to read, can be repeated
   -S, --sort {option}   how to sort progress information; default: by retention; available options: attempts,
                         retention
@@ -185,7 +187,7 @@ Options:
             command="practice",
             target_language="nl",
             source_language="fi",
-            concept=[],
+            concepts=[],
             file=[],
         )
         self.assertEqual(expected_namespace, parse_arguments(self.argument_parser()))


### PR DESCRIPTION
Change the command line option to specify concepts into positional arguments so users don't have to type `--concept` or `-c` before each concept.

Closes #631.