### PR TITLE
Fix examples with spelling alternative.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Toisto will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- When showing examples, show only one spelling alternative. Fixes [#639](https://github.com/fniessink/toisto/issues/639).
+
 ## 0.18.0 - 2024-04-06
 
 ### Changed

--- a/src/toisto/ui/text.py
+++ b/src/toisto/ui/text.py
@@ -101,7 +101,8 @@ def examples(quiz: Quiz) -> str:
     """Return the quiz's examples, if any."""
     examples: list[Label] = []
     for example in quiz.concept.get_related_concepts("example"):
-        examples.extend(example.labels(quiz.question_language))
+        labels = [label.non_generated_spelling_alternatives[0] for label in example.labels(quiz.question_language)]
+        examples.extend(labels)
     return bulleted_list("Example", examples)
 
 

--- a/tests/toisto/ui/test_text.py
+++ b/tests/toisto/ui/test_text.py
@@ -151,6 +151,14 @@ class FeedbackTestCase(ToistoTestCase):
             feedback_incorrect(Label(self.fi, "?"), quiz).split("\n")[-2],
         )
 
+    def test_post_quiz_example_with_spelling_alternatives(self):
+        """Test that the post quiz example is formatted correctly when the example has spelling alternatives."""
+        hi = self.create_concept("hi", dict(nl="hoi", fi="terve", example="hi alice"))
+        self.create_concept("hi alice", dict(fi="Moi Alice!|Hei Alice!"))
+        quiz = create_quizzes(self.fi, self.fi, hi).by_quiz_type("read").pop()
+        feedback_text = feedback_correct(self.guess, quiz)
+        self.assertEqual(CORRECT + f"[{SECONDARY}]Example: Moi Alice![/{SECONDARY}]\n", feedback_text)
+
 
 class LinkifyTest(TestCase):
     """Unit tests for the linkify method."""


### PR DESCRIPTION
When showing examples, show only one spelling alternative.

Fixes #639.