### PR TITLE
Split the "head" concept into two concepts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - When showing examples, show only one spelling alternative. Fixes [#639](https://github.com/fniessink/toisto/issues/639).
 - When quizzing colloquial language (which is quizzed spoken only), show the colloquial language after the quiz. Fixes [#640](https://github.com/fniessink/toisto/issues/640).
+- Split the "head" concept into two different concepts: head as in part of a human or animal body and head as in the main part of something. Fixes [#643](https://github.com/fniessink/toisto/issues/643).
 
 ## 0.18.0 - 2024-04-06
 

--- a/src/concepts/linguistics.json
+++ b/src/concepts/linguistics.json
@@ -162,11 +162,11 @@
         "roots": {
             "en": "verb",
             "fi": [
-                "head",
+                "head (main part)",
                 "verb"
             ],
             "nl": [
-                "head",
+                "head (main part)",
                 "verb"
             ]
         },

--- a/src/concepts/mixed/food.json
+++ b/src/concepts/mixed/food.json
@@ -138,10 +138,10 @@
         "holonym": "meal",
         "roots": {
             "fi": [
-                "head",
+                "head (main part)",
                 "food"
             ],
-            "nl": "head"
+            "nl": "head (main part)"
         },
         "en": [
             "main dish",

--- a/src/concepts/nouns/capital.json
+++ b/src/concepts/nouns/capital.json
@@ -4,11 +4,11 @@
         "roots": {
             "fi": [
                 "city",
-                "head"
+                "head (main part)"
             ],
             "nl": [
                 "city",
-                "head"
+                "head (main part)"
             ]
         },
         "singular": {

--- a/src/concepts/nouns/chapter.json
+++ b/src/concepts/nouns/chapter.json
@@ -2,7 +2,7 @@
     "chapter": {
         "holonym": "book",
         "roots": {
-            "nl": "head"
+            "nl": "head (main part)"
         },
         "singular": {
             "en": "chapter",

--- a/src/concepts/nouns/head.json
+++ b/src/concepts/nouns/head.json
@@ -21,5 +21,17 @@
         "en": "forehead",
         "fi": "otsa",
         "nl": "het voorhoofd"
+    },
+    "head (main part)": {
+        "singular": {
+            "en": "head",
+            "fi": "pää",
+            "nl": "het hoofd"
+        },
+        "plural": {
+            "en": "heads",
+            "fi": "päät",
+            "nl": "de hoofden"
+        }
     }
 }

--- a/src/concepts/nouns/station.json
+++ b/src/concepts/nouns/station.json
@@ -48,7 +48,7 @@
         "hypernym": "train station",
         "roots": {
             "fi": [
-                "head",
+                "head (main part)",
                 "station"
             ],
             "nl": [


### PR DESCRIPTION
Split the "head" concept into two different concepts: head as in part of a human or animal body and head as in the main part of something.

Fixes #643.