### PR TITLE
Fix quizzes of colloquial sentences.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - When showing examples, show only one spelling alternative. Fixes [#639](https://github.com/fniessink/toisto/issues/639).
 - When quizzing colloquial language (which is quizzed spoken only), show the colloquial language after the quiz. Fixes [#640](https://github.com/fniessink/toisto/issues/640).
 - Split the "head" concept into two different concepts: head as in part of a human or animal body and head as in the main part of something. Fixes [#643](https://github.com/fniessink/toisto/issues/643).
+- When quizzing a colloquial sentence, mention that the user is expected to enter a complete sentence. Fixes [#645](https://github.com/fniessink/toisto/issues/645).
 
 ## 0.18.0 - 2024-04-06
 

--- a/src/toisto/model/language/label.py
+++ b/src/toisto/model/language/label.py
@@ -94,7 +94,8 @@ class Label(str):
     @property
     def is_complete_sentence(self) -> bool:
         """Return whether this is a complete sentence (starts with a capital and ends with punctuation)."""
-        return self.without_notes[0].isupper() and (self.without_notes[-1] in END_OF_SENTENCE_PUNCTUATION)
+        label = self.without_notes
+        return label[0].isupper() and (label.strip(self.COLLOQUIAL_POSTFIX)[-1] in END_OF_SENTENCE_PUNCTUATION)
 
     @property
     def pronounceable(self) -> str:

--- a/tests/toisto/model/language/test_label.py
+++ b/tests/toisto/model/language/test_label.py
@@ -15,3 +15,8 @@ class LabelTest(ToistoTestCase):
         self.assertFalse(equal_to_object)
         not_equal_to_object = label != object()
         self.assertTrue(not_equal_to_object)
+
+    def test_complete_sentence(self):
+        """Test that a colloquial sentence is recognized."""
+        label = Label(self.fi, "Kiitti!*")
+        self.assertTrue(label.is_complete_sentence)


### PR DESCRIPTION
When quizzing a colloquial sentence, mention that the user is expected to enter a complete sentence.

Fixes #645.