### PR TITLE
Show examples in the correct language.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - When quizzing colloquial language (which is quizzed spoken only), show the colloquial language after the quiz. Fixes [#640](https://github.com/fniessink/toisto/issues/640).
 - Split the "head" concept into two different concepts: head as in part of a human or animal body and head as in the main part of something. Fixes [#643](https://github.com/fniessink/toisto/issues/643).
 - When quizzing a colloquial sentence, mention that the user is expected to enter a complete sentence. Fixes [#645](https://github.com/fniessink/toisto/issues/645).
+- When quizzing a translation from source language to target language, show any examples in the target language. Fixes [#649](https://github.com/fniessink/toisto/issues/649).
 
 ## 0.18.0 - 2024-04-06
 

--- a/src/toisto/ui/text.py
+++ b/src/toisto/ui/text.py
@@ -109,8 +109,9 @@ def other_answers(guess: Label, quiz: Quiz) -> str:
 def examples(quiz: Quiz) -> str:
     """Return the quiz's examples, if any."""
     examples: list[Label] = []
+    language = quiz.answer_language if "write" in quiz.quiz_types else quiz.question_language
     for example in quiz.concept.get_related_concepts("example"):
-        labels = [label.non_generated_spelling_alternatives[0] for label in example.labels(quiz.question_language)]
+        labels = [label.non_generated_spelling_alternatives[0] for label in example.labels(language)]
         examples.extend(labels)
     return bulleted_list("Example", examples)
 

--- a/tests/toisto/ui/test_text.py
+++ b/tests/toisto/ui/test_text.py
@@ -174,6 +174,14 @@ class FeedbackTestCase(ToistoTestCase):
         feedback_text = feedback_correct(self.guess, quiz)
         self.assertEqual(CORRECT + f"[{SECONDARY}]Example: Moi Alice![/{SECONDARY}]\n", feedback_text)
 
+    def test_post_quiz_example_with_write_quiz(self):
+        """Test that the post quiz example is in the right language when the quiz type is write."""
+        hi = self.create_concept("hi", dict(nl="hoi", fi="terve", example="hi alice"))
+        self.create_concept("hi alice", dict(fi="Terve Alice!", nl="Hoi Alice!"))
+        quiz = create_quizzes(self.fi, self.nl, hi).by_quiz_type("write").pop()
+        feedback_text = feedback_correct(self.guess, quiz)
+        self.assertEqual(CORRECT + f"[{SECONDARY}]Example: Terve Alice![/{SECONDARY}]\n", feedback_text)
+
 
 class LinkifyTest(TestCase):
     """Unit tests for the linkify method."""


### PR DESCRIPTION
When quizzing a translation from source language to target language, show any examples in the target language.

Fixes #649.