### PR TITLE
Accept a capitalized guess when possible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Fixed
+
+- Accept an initial capital letter when both the question and the answer of a quiz are in lower case. Fixes [#671](https://github.com/fniessink/toisto/issues/671).
+
 ### Added
 
 - Add support for the present perfect tense. Closes [#632](https://github.com/fniessink/toisto/issues/632).
 - When showing examples, also show the meaning of the examples. Closes [#638](https://github.com/fniessink/toisto/issues/638).
+- Add several concepts.
 
 ## 0.18.1 - 2024-04-09
 

--- a/src/toisto/model/quiz/quiz.py
+++ b/src/toisto/model/quiz/quiz.py
@@ -120,7 +120,8 @@ class Quiz:
 
     def is_correct(self, guess: Label) -> bool:
         """Return whether the guess is correct."""
-        return match(guess, *self.answers)
+        ignore_first_upper_case = not self.question.starts_with_upper_case and not self.answer.starts_with_upper_case
+        return match(guess.with_lower_case_first_letter if ignore_first_upper_case else guess, *self.answers)
 
     def is_question(self, guess: Label) -> bool:
         """Return whether the guess is not the answer, but the question (common user error with listening quizzes)."""

--- a/tests/toisto/command/test_practice.py
+++ b/tests/toisto/command/test_practice.py
@@ -23,7 +23,7 @@ class PracticeTest(ToistoTestCase):
     def setUp(self) -> None:
         """Set up the test fixtures."""
         super().setUp()
-        self.concept = self.create_concept("hi", dict(fi="Terve", nl="Hoi"))
+        self.concept = self.create_concept("hi", dict(fi="Terve!", nl="Hoi!"))
         self.quizzes = create_quizzes(FI_NL, self.concept).by_quiz_type("read")
 
     def practice(self, quizzes: Quizzes) -> Mock:
@@ -48,13 +48,13 @@ class PracticeTest(ToistoTestCase):
         patched_print = self.practice(self.quizzes)
         self.assertIn(call(CORRECT), patched_print.call_args_list)
 
-    @patch("builtins.input", Mock(side_effect=["H o i\n", "Ho i\n"]))
+    @patch("builtins.input", Mock(side_effect=["H o i!\n", "Ho i!\n"]))
     def test_answer_with_spaces(self):
         """Test that answers with spaces inside are not considered correct."""
         patched_print = self.practice(self.quizzes)
         self.assertIn(call(TRY_AGAIN), patched_print.call_args_list)
         self.assertIn(
-            call(f'{INCORRECT}The correct answer is "Ho[{DELETED}]_[/{DELETED}]i".\n'),
+            call(f'{INCORRECT}The correct answer is "Ho[{DELETED}]_[/{DELETED}]i!".\n'),
             patched_print.call_args_list,
         )
 
@@ -90,7 +90,7 @@ class PracticeTest(ToistoTestCase):
     def test_quiz_question(self):
         """Test that the question is printed."""
         patched_print = self.practice(self.quizzes)
-        self.assertIn(call(linkify("Terve")), patched_print.call_args_list)
+        self.assertIn(call(linkify("Terve!")), patched_print.call_args_list)
 
     @patch("builtins.input", Mock(return_value="hoi\n"))
     def test_quiz_listen(self):
@@ -104,7 +104,7 @@ class PracticeTest(ToistoTestCase):
         """Test that the translation is not printed on a non-translate quiz."""
         quizzes = create_quizzes(FI_NL, self.concept).by_quiz_type("dictate")
         patched_print = self.practice(quizzes)
-        expected_text = f'{CORRECT}[{SECONDARY}]Meaning "{linkify("Hoi")}".[/{SECONDARY}]\n'
+        expected_text = f'{CORRECT}[{SECONDARY}]Meaning "{linkify("Hoi!")}".[/{SECONDARY}]\n'
         self.assertIn(call(expected_text), patched_print.call_args_list)
 
     @patch("builtins.input", Mock(return_value="talot\n"))
@@ -168,14 +168,14 @@ class PracticeTest(ToistoTestCase):
         """Test that the user is quizzed."""
         patched_print = self.practice(self.quizzes)
         self.assertNotIn(call(TRY_AGAIN), patched_print.call_args_list)
-        self.assertIn(call(f'The correct answer is "{linkify("Hoi")}".\n'), patched_print.call_args_list)
+        self.assertIn(call(f'The correct answer is "{linkify("Hoi!")}".\n'), patched_print.call_args_list)
 
     @patch("builtins.input", Mock(side_effect=["first attempt", "?\n", EOFError]))
     def test_quiz_skip_on_second_attempt(self):
         """Test that the user is quizzed."""
         patched_print = self.practice(self.quizzes)
         self.assertIn(call(TRY_AGAIN), patched_print.call_args_list)
-        self.assertIn(call(f'The correct answer is "{linkify("Hoi")}".\n'), patched_print.call_args_list)
+        self.assertIn(call(f'The correct answer is "{linkify("Hoi!")}".\n'), patched_print.call_args_list)
 
     @patch("builtins.input", Mock(side_effect=["hoi\n", "hoi\n"]))
     def test_quiz_done(self):

--- a/tests/toisto/model/quiz/test_quiz.py
+++ b/tests/toisto/model/quiz/test_quiz.py
@@ -50,6 +50,20 @@ class QuizTest(QuizTestCase):
         """Test an incorrect guess."""
         self.assertFalse(self.quiz.is_correct(Label(NL, "engles")))
 
+    def test_is_not_correct_due_to_upper_case_question(self):
+        """Test that a lower case answer for an upper case question is incorrect."""
+        self.assertFalse(self.quiz.is_correct(Label(NL, "engels")))
+
+    def test_is_not_correct_due_to_upper_case_answer(self):
+        """Test that a lower case answer is incorrect when the answer should be upper case."""
+        quiz = self.create_quiz(self.create_concept("finnish", {}), "suomi", ["Fins"])
+        self.assertFalse(quiz.is_correct(Label(NL, "fins")))
+
+    def test_is_correct_despite_case(self):
+        """Test that an upper case answer for a lower case question is correct."""
+        quiz = self.create_quiz(self.create_concept("house", {}), "talo", ["het huis"])
+        self.assertTrue(quiz.is_correct(Label(NL, "Het huis")))
+
     def test_get_answer(self):
         """Test that the answer is returned."""
         self.assertEqual(self.engels, self.quiz.answer)
@@ -188,24 +202,24 @@ class QuizSpellingAlternativesTests(QuizTestCase):
 
     def test_spelling_alternative_of_answer(self):
         """Test that a quiz can deal with alternative spellings of answers."""
-        quiz = self.create_quiz(self.concept, "Yksi", ["Een|Eén"])
-        self.assertEqual(Label(NL, "Een"), quiz.answer)
+        quiz = self.create_quiz(self.concept, "yksi", ["een|één"])
+        self.assertEqual(Label(NL, "een"), quiz.answer)
 
     def test_spelling_alternative_of_question(self):
         """Test that a quiz can deal with alternative spellings of the question."""
         self.language_pair = NL_FI
-        quiz = self.create_quiz(self.concept, "Een|Eén", ["Yksi"])
-        self.assertEqual(Label(NL, "Een"), quiz.question)
+        quiz = self.create_quiz(self.concept, "een|één", ["yksi"])
+        self.assertEqual(Label(NL, "een"), quiz.question)
 
     def test_spelling_alternative_is_correct(self):
         """Test that an answer that matches a spelling alternative is correct."""
-        quiz = self.create_quiz(self.concept, "Yksi", ["Een|Eén", "één"])
+        quiz = self.create_quiz(self.concept, "Yksi.", ["Een|Eén", "één"])
         for alternative in ("Een", "Eén", "één"):
             self.assertTrue(quiz.is_correct(Label(NL, alternative)))
 
     def test_other_answers_with_spelling_alternatives(self):
         """Test the spelling alternatives are returned as other answers."""
-        quiz = self.create_quiz(self.concept, "Yksi", ["Een|Eén", "één"])
+        quiz = self.create_quiz(self.concept, "Yksi.", ["Een|Eén", "één"])
         alternatives = ("Een", "Eén", "één")
         for alternative in alternatives:
             other_answers = list(alternatives)
@@ -217,7 +231,7 @@ class QuizSpellingAlternativesTests(QuizTestCase):
         """Test that a generated spelling alternative is accepted as answer."""
         load_spelling_alternatives(EN_NL)
         self.language_pair = NL_EN
-        quiz = self.create_quiz(self.concept, "Het is waar", ["It is true"])
+        quiz = self.create_quiz(self.concept, "Het is waar.", ["It is true."])
         self.assertTrue(quiz.is_correct(Label(EN, "It's true")))
         quiz = self.create_quiz(self.concept, "Het is.", ["It is."])
         self.assertTrue(quiz.is_correct(Label(EN, "It's.")))


### PR DESCRIPTION
Accept an initial capital letter in the user's guess when both the question and the answer of quiz are in lower case.

Fixes #671.