### PR TITLE
Improve feedback formatting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 
 - Accept an initial capital letter when both the question and the answer of a quiz are in lower case. Fixes [#671](https://github.com/fniessink/toisto/issues/671).
+- Use single quotes when referring to questions and answers in user feedback. When feedback ends with a quoted question or answer, only add a period if the quoted question or answer does not already end with punctuation. Fixes [#675](https://github.com/fniessink/toisto/issues/675).
 
 ### Added
 

--- a/src/toisto/command/practice.py
+++ b/src/toisto/command/practice.py
@@ -9,7 +9,7 @@ from toisto.model.language.label import Label
 from toisto.model.quiz.progress import Progress
 from toisto.model.quiz.quiz import ListenQuizType, Quiz
 from toisto.persistence.progress import save_progress
-from toisto.ui.dictionary import linkify
+from toisto.ui.dictionary import linkified
 from toisto.ui.speech import say
 from toisto.ui.text import (
     DONE,
@@ -61,7 +61,7 @@ def do_quiz(
     """Do one quiz and update the progress."""
     write_output(instruction(quiz))
     if quiz.quiz_types[0] not in get_args(ListenQuizType):
-        write_output(linkify(quiz.question))
+        write_output(linkified(quiz.question))
     for attempt in range(1, 3):
         answer = do_quiz_attempt(quiz, config, attempt)
         feedback = evaluate_answer(quiz, progress, language_pair, answer, attempt)

--- a/src/toisto/model/language/label.py
+++ b/src/toisto/model/language/label.py
@@ -11,7 +11,7 @@ from . import Language
 
 SpellingAlternatives = dict[Language, dict[re.Pattern[str], str]]
 
-END_OF_SENTENCE_PUNCTUATION = """?!'"."""
+END_OF_SENTENCE_PUNCTUATION = "?!."
 
 
 class Label(str):

--- a/src/toisto/ui/dictionary.py
+++ b/src/toisto/ui/dictionary.py
@@ -6,12 +6,7 @@ from typing import Final
 DICTIONARY_URL: Final = "https://en.wiktionary.org/wiki"
 
 
-def linkify_and_enumerate(*texts: str, sep: str = ", ") -> str:
-    """Return a linkified and enumerated version of the texts."""
-    return sep.join(f'"{linkify(text)}"' for text in texts)
-
-
-def linkify(text: str) -> str:
+def linkified(text: str) -> str:
     """Return a version of the text where each word is turned into a link to a dictionary."""
     linkified_words = []
     for word in text.split():

--- a/src/toisto/ui/diff.py
+++ b/src/toisto/ui/diff.py
@@ -2,7 +2,7 @@
 
 from difflib import SequenceMatcher
 
-from .dictionary import linkify
+from .dictionary import linkified
 from .style import DELETED, INSERTED
 
 
@@ -25,7 +25,7 @@ def colored_diff(old_text: str, new_text: str, min_ratio_for_diff: float = 0.6) 
     """Return a colored string showing the diffs between old and new text."""
     matcher = SequenceMatcher(a=old_text.lower(), b=new_text.lower())
     if matcher.ratio() < min_ratio_for_diff:
-        return inserted(linkify(new_text))
+        return inserted(linkified(new_text))
     result = ""
     for operator, old_start, old_end, new_start, new_end in matcher.get_opcodes():
         old_fragment, new_fragment = (old_text[old_start:old_end], new_text[new_start:new_end])

--- a/tests/toisto/command/test_practice.py
+++ b/tests/toisto/command/test_practice.py
@@ -7,7 +7,7 @@ from toisto.command.practice import practice
 from toisto.model.quiz.progress import Progress
 from toisto.model.quiz.quiz import Quizzes
 from toisto.model.quiz.quiz_factory import create_quizzes
-from toisto.ui.dictionary import linkify
+from toisto.ui.dictionary import linkified
 from toisto.ui.style import DELETED, SECONDARY
 from toisto.ui.text import CORRECT, DONE, INCORRECT, TRY_AGAIN, TRY_AGAIN_IN_ANSWER_LANGUAGE, console
 
@@ -54,7 +54,7 @@ class PracticeTest(ToistoTestCase):
         patched_print = self.practice(self.quizzes)
         self.assertIn(call(TRY_AGAIN), patched_print.call_args_list)
         self.assertIn(
-            call(f'{INCORRECT}The correct answer is "Ho[{DELETED}]_[/{DELETED}]i!".\n'),
+            call(f"{INCORRECT}The correct answer is 'Ho[{DELETED}]_[/{DELETED}]i!'\n"),
             patched_print.call_args_list,
         )
 
@@ -90,21 +90,21 @@ class PracticeTest(ToistoTestCase):
     def test_quiz_question(self):
         """Test that the question is printed."""
         patched_print = self.practice(self.quizzes)
-        self.assertIn(call(linkify("Terve!")), patched_print.call_args_list)
+        self.assertIn(call(linkified("Terve!")), patched_print.call_args_list)
 
     @patch("builtins.input", Mock(return_value="hoi\n"))
     def test_quiz_listen(self):
         """Test that the question is not printed on a listening quiz."""
         quizzes = create_quizzes(FI_NL, self.concept).by_quiz_type("dictate")
         patched_print = self.practice(quizzes)
-        self.assertNotIn(call(linkify("Terve")), patched_print.call_args_list)
+        self.assertNotIn(call(linkified("Terve")), patched_print.call_args_list)
 
     @patch("builtins.input", Mock(return_value="Terve\n"))
     def test_quiz_non_translate(self):
         """Test that the translation is not printed on a non-translate quiz."""
         quizzes = create_quizzes(FI_NL, self.concept).by_quiz_type("dictate")
         patched_print = self.practice(quizzes)
-        expected_text = f'{CORRECT}[{SECONDARY}]Meaning "{linkify("Hoi!")}".[/{SECONDARY}]\n'
+        expected_text = f"{CORRECT}[{SECONDARY}]Meaning '{linkified('Hoi!')}'[/{SECONDARY}]\n"
         self.assertIn(call(expected_text), patched_print.call_args_list)
 
     @patch("builtins.input", Mock(return_value="talot\n"))
@@ -117,7 +117,8 @@ class PracticeTest(ToistoTestCase):
         quizzes = create_quizzes(FI_NL, concept).by_quiz_type("pluralize")
         patched_print = self.practice(Quizzes(quizzes))
         expected_call = call(
-            f'{CORRECT}[{SECONDARY}]Meaning "{linkify("huis")}", respectively "{linkify("huizen")}".[/{SECONDARY}]\n',
+            f"{CORRECT}[{SECONDARY}]Meaning '{linkified('huis')}', "
+            f"respectively '{linkified('huizen')}'.[/{SECONDARY}]\n",
         )
         self.assertIn(expected_call, patched_print.call_args_list)
 
@@ -135,8 +136,8 @@ class PracticeTest(ToistoTestCase):
         quizzes = create_quizzes(FI_NL, concept).by_quiz_type("dictate")
         patched_print = self.practice(Quizzes(quizzes))
         expected_call = call(
-            f'{CORRECT}[{SECONDARY}]Meaning "{linkify("naast")}".[/{SECONDARY}]\n'
-            f'[{SECONDARY}]Example: "Museo on kirkon vieressä." meaning "Het museum is naast de kerk."[/{SECONDARY}]\n'
+            f"{CORRECT}[{SECONDARY}]Meaning '{linkified('naast')}'.[/{SECONDARY}]\n"
+            f"[{SECONDARY}]Example: 'Museo on kirkon vieressä.' meaning 'Het museum is naast de kerk.'[/{SECONDARY}]\n"
         )
         self.assertIn(expected_call, patched_print.call_args_list)
 
@@ -150,9 +151,9 @@ class PracticeTest(ToistoTestCase):
         quizzes = create_quizzes(FI_NL, concept).by_quiz_type("dictate")
         patched_print = self.practice(Quizzes(quizzes))
         expected_call = call(
-            f'{CORRECT}[{SECONDARY}]Meaning "{linkify("zwart")}".[/{SECONDARY}]\n'
-            f'[{SECONDARY}]Examples:\n- "Auto on musta." meaning "De auto is zwart."\n'
-            f'- "Autot ovat mustia." meaning "De auto\'s zijn zwart."[/{SECONDARY}]\n'
+            f"{CORRECT}[{SECONDARY}]Meaning '{linkified('zwart')}'.[/{SECONDARY}]\n"
+            f"[{SECONDARY}]Examples:\n- 'Auto on musta.' meaning 'De auto is zwart.'\n"
+            f"- 'Autot ovat mustia.' meaning 'De auto's zijn zwart.'[/{SECONDARY}]\n"
         )
         self.assertIn(expected_call, patched_print.call_args_list)
 
@@ -168,14 +169,14 @@ class PracticeTest(ToistoTestCase):
         """Test that the user is quizzed."""
         patched_print = self.practice(self.quizzes)
         self.assertNotIn(call(TRY_AGAIN), patched_print.call_args_list)
-        self.assertIn(call(f'The correct answer is "{linkify("Hoi!")}".\n'), patched_print.call_args_list)
+        self.assertIn(call(f"The correct answer is '{linkified('Hoi!')}'\n"), patched_print.call_args_list)
 
     @patch("builtins.input", Mock(side_effect=["first attempt", "?\n", EOFError]))
     def test_quiz_skip_on_second_attempt(self):
         """Test that the user is quizzed."""
         patched_print = self.practice(self.quizzes)
         self.assertIn(call(TRY_AGAIN), patched_print.call_args_list)
-        self.assertIn(call(f'The correct answer is "{linkify("Hoi!")}".\n'), patched_print.call_args_list)
+        self.assertIn(call(f"The correct answer is '{linkified('Hoi!')}'\n"), patched_print.call_args_list)
 
     @patch("builtins.input", Mock(side_effect=["hoi\n", "hoi\n"]))
     def test_quiz_done(self):

--- a/tests/toisto/ui/test_diff.py
+++ b/tests/toisto/ui/test_diff.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from toisto.ui.dictionary import linkify
+from toisto.ui.dictionary import linkified
 from toisto.ui.diff import colored_diff
 from toisto.ui.style import DELETED, INSERTED
 
@@ -16,7 +16,7 @@ class DiffTest(unittest.TestCase):
 
     def test_wildly_different_strings(self):
         """Test that wildly different strings are green."""
-        self.assertEqual(f"[{INSERTED}]{linkify('different')}[/{INSERTED}]", colored_diff("completely", "different"))
+        self.assertEqual(f"[{INSERTED}]{linkified('different')}[/{INSERTED}]", colored_diff("completely", "different"))
 
     def test_text_deleted(self):
         """Test that deleted parts are red."""
@@ -50,4 +50,4 @@ class DiffTest(unittest.TestCase):
 
     def test_make_inserted_whitespace_not_visible(self):
         """Test that inserted whitespace is not made visible."""
-        self.assertEqual(f"[{INSERTED}]{linkify('de morgen')}[/{INSERTED}]", colored_diff("uhm", "de morgen"))
+        self.assertEqual(f"[{INSERTED}]{linkified('de morgen')}[/{INSERTED}]", colored_diff("uhm", "de morgen"))

--- a/tests/toisto/ui/test_text.py
+++ b/tests/toisto/ui/test_text.py
@@ -6,7 +6,7 @@ from toisto.model.language import FI, NL
 from toisto.model.language.label import Label
 from toisto.model.quiz.quiz_factory import create_quizzes
 from toisto.persistence.spelling_alternatives import load_spelling_alternatives
-from toisto.ui.dictionary import DICTIONARY_URL, linkify
+from toisto.ui.dictionary import DICTIONARY_URL, linkified
 from toisto.ui.style import INSERTED, QUIZ, SECONDARY
 from toisto.ui.text import CORRECT, INCORRECT, feedback_correct, feedback_incorrect, feedback_skip, instruction
 
@@ -32,12 +32,12 @@ class FeedbackTestCase(ToistoTestCase):
     def test_show_colloquial_language(self):
         """Test that the colloquial language, that is only spoken, is shown."""
         concept = self.create_concept("thanks", dict(nl="dank", fi=["kiitos", "kiitti*"]))
-        colloquial = f'[{SECONDARY}]The colloquial Finnish spoken was "kiitti".[/{SECONDARY}]\n'
-        meaning = f'[{SECONDARY}]Meaning "{linkify("dank")}".[/{SECONDARY}]\n'
-        answer = f'The correct answer is "[{INSERTED}]{linkify("kiitos")}[/{INSERTED}]".\n'
+        colloquial = f"[{SECONDARY}]The colloquial Finnish spoken was 'kiitti'.[/{SECONDARY}]\n"
+        meaning = f"[{SECONDARY}]Meaning '{linkified('dank')}'.[/{SECONDARY}]\n"
+        answer = f"The correct answer is '[{INSERTED}]{linkified('kiitos')}[/{INSERTED}]'.\n"
         expected_feedback_correct = CORRECT + colloquial + meaning
         expected_feedback_incorrect = INCORRECT + answer + colloquial + meaning
-        expected_feedback_on_skip = f'The correct answer is "{linkify("kiitos")}".\n' + colloquial + meaning
+        expected_feedback_on_skip = f"The correct answer is '{linkified('kiitos')}'.\n" + colloquial + meaning
         for quiz in create_quizzes(FI_NL, concept).by_quiz_type("dictate"):
             if quiz.question.is_colloquial:
                 self.assertEqual(expected_feedback_correct, feedback_correct(Label(FI, "kiitos"), quiz, FI_NL))
@@ -48,16 +48,16 @@ class FeedbackTestCase(ToistoTestCase):
         """Test that alternative answers are shown."""
         concept = self.create_concept("hi", dict(nl="hoi", fi=["terve", "hei"]))
         quiz = create_quizzes(NL_FI, concept).by_quiz_type("read").pop()
-        expected_other_answer = linkify(quiz.other_answers(self.guess)[0])
-        expected_text = f'{CORRECT}[{SECONDARY}]Another correct answer is "{expected_other_answer}".[/{SECONDARY}]\n'
+        expected_other_answer = linkified(quiz.other_answers(self.guess)[0])
+        expected_text = f"{CORRECT}[{SECONDARY}]Another correct answer is '{expected_other_answer}'.[/{SECONDARY}]\n"
         self.assertEqual(expected_text, feedback_correct(self.guess, quiz, NL_FI))
 
     def test_show_alternative_answers(self):
         """Test that alternative answers are shown."""
         concept = self.create_concept("hi", dict(nl="hoi", fi=["terve", "hei", "hei hei"]))
         quiz = create_quizzes(NL_FI, concept).by_quiz_type("read").pop()
-        other_answers = [f'"{linkify(answer)}"' for answer in quiz.other_answers(self.guess)]
-        expected_text = f'{CORRECT}[{SECONDARY}]Other correct answers are {", ".join(other_answers)}.[/{SECONDARY}]\n'
+        other_answers = [f"'{linkified(answer)}'" for answer in quiz.other_answers(self.guess)]
+        expected_text = f"{CORRECT}[{SECONDARY}]Other correct answers are {', '.join(other_answers)}.[/{SECONDARY}]\n"
         self.assertEqual(expected_text, feedback_correct(self.guess, quiz, NL_FI))
 
     def test_show_feedback_on_incorrect_guess(self):
@@ -65,8 +65,8 @@ class FeedbackTestCase(ToistoTestCase):
         concept = self.create_concept("hi", dict(nl="hoi", fi="terve"))
         quiz = create_quizzes(FI_NL, concept).by_quiz_type("dictate").pop()
         expected_text = (
-            f'{INCORRECT}The correct answer is "[{INSERTED}]{linkify("terve")}[/{INSERTED}]".\n'
-            f'[{SECONDARY}]Meaning "{linkify("hoi")}".[/{SECONDARY}]\n'
+            f"{INCORRECT}The correct answer is '[{INSERTED}]{linkified('terve')}[/{INSERTED}]'.\n"
+            f"[{SECONDARY}]Meaning '{linkified('hoi')}'.[/{SECONDARY}]\n"
         )
         self.assertEqual(expected_text, feedback_incorrect(Label(FI, "incorrect"), quiz))
 
@@ -75,8 +75,8 @@ class FeedbackTestCase(ToistoTestCase):
         concept = self.create_concept("hi", dict(nl="hoi", fi=["terve", "hei"]))
         quiz = create_quizzes(NL_FI, concept).by_quiz_type("read").pop()
         expected_text = (
-            f'{INCORRECT}The correct answer is "[{INSERTED}]{linkify("terve")}[/{INSERTED}]".\n'
-            f'[{SECONDARY}]Another correct answer is "{linkify("hei")}".[/{SECONDARY}]\n'
+            f"{INCORRECT}The correct answer is '[{INSERTED}]{linkified('terve')}[/{INSERTED}]'.\n"
+            f"[{SECONDARY}]Another correct answer is '{linkified('hei')}'.[/{SECONDARY}]\n"
         )
         self.assertEqual(expected_text, feedback_incorrect(Label(FI, "incorrect"), quiz))
 
@@ -84,14 +84,14 @@ class FeedbackTestCase(ToistoTestCase):
         """Test that generated alternative answers are not shown when the user guesses incorrectly."""
         concept = self.create_concept("house", dict(nl="het huis", fi=["talo"]))
         quiz = create_quizzes(FI_NL, concept).by_quiz_type("read").pop()
-        expected_text = f'{INCORRECT}The correct answer is "[{INSERTED}]{linkify("het huis")}[/{INSERTED}]".\n'
+        expected_text = f"{INCORRECT}The correct answer is '[{INSERTED}]{linkified('het huis')}[/{INSERTED}]'.\n"
         self.assertEqual(expected_text, feedback_incorrect(Label(NL, "incorrect"), quiz))
 
     def test_do_not_show_generated_alternative_answers_on_question_mark(self):
         """Test that generated alternative answers are not shown when the user enters a question mark."""
         concept = self.create_concept("house", dict(nl="het huis", fi=["talo"]))
         quiz = create_quizzes(FI_NL, concept).by_quiz_type("read").pop()
-        expected_text = f'The correct answer is "{linkify("het huis")}".\n'
+        expected_text = f"The correct answer is '{linkified('het huis')}'.\n"
         self.assertEqual(expected_text, feedback_skip(quiz))
 
     def test_show_feedback_on_question_mark(self):
@@ -99,7 +99,7 @@ class FeedbackTestCase(ToistoTestCase):
         concept = self.create_concept("hi", dict(nl="hoi", fi="terve"))
         quiz = create_quizzes(FI_NL, concept).by_quiz_type("dictate").pop()
         expected_text = (
-            f'The correct answer is "{linkify("terve")}".\n[{SECONDARY}]Meaning "{linkify("hoi")}".[/{SECONDARY}]\n'
+            f"The correct answer is '{linkified('terve')}'.\n[{SECONDARY}]Meaning '{linkified('hoi')}'.[/{SECONDARY}]\n"
         )
         self.assertEqual(expected_text, feedback_skip(quiz))
 
@@ -108,8 +108,8 @@ class FeedbackTestCase(ToistoTestCase):
         concept = self.create_concept("hi", dict(nl="hoi", fi=["terve", "hei"]))
         quiz = create_quizzes(NL_FI, concept).by_quiz_type("read").pop()
         expected_text = (
-            'The correct answers are "[link=https://en.wiktionary.org/wiki/terve]terve[/link]", '
-            '"[link=https://en.wiktionary.org/wiki/hei]hei[/link]".\n'
+            "The correct answers are '[link=https://en.wiktionary.org/wiki/terve]terve[/link]', "
+            "'[link=https://en.wiktionary.org/wiki/hei]hei[/link]'.\n"
         )
         self.assertEqual(expected_text, feedback_skip(quiz))
 
@@ -132,10 +132,10 @@ class FeedbackTestCase(ToistoTestCase):
 
     def test_post_quiz_note(self):
         """Test that the post quiz note is formatted correctly."""
-        concept = self.create_concept("hi", dict(nl="hoi;;Hoi is an informal greeting"))
+        concept = self.create_concept("hi", dict(nl="hoi;;'Hoi' is an informal greeting"))
         quiz = create_quizzes(NL_FI, concept).by_quiz_type("dictate").pop()
         self.assertEqual(
-            f"[{SECONDARY}]Note: Hoi is an informal greeting.[/{SECONDARY}]",
+            f"[{SECONDARY}]Note: 'Hoi' is an informal greeting.[/{SECONDARY}]",
             feedback_correct(Label(NL, "hoi"), quiz, NL_FI).split("\n")[-2],
         )
 
@@ -150,19 +150,19 @@ class FeedbackTestCase(ToistoTestCase):
 
     def test_post_quiz_note_on_incorrect_answer(self):
         """Test that the post quiz note is formatted correctly."""
-        concept = self.create_concept("hi", dict(fi="moi;;Moi is an informal greeting"))
+        concept = self.create_concept("hi", dict(fi="moi;;'Moi' is an informal greeting"))
         quiz = create_quizzes(FI_NL, concept).by_quiz_type("dictate").pop()
         self.assertEqual(
-            f"[{SECONDARY}]Note: Moi is an informal greeting.[/{SECONDARY}]",
+            f"[{SECONDARY}]Note: 'Moi' is an informal greeting.[/{SECONDARY}]",
             feedback_incorrect(Label(FI, "toi"), quiz).split("\n")[-2],
         )
 
     def test_post_quiz_note_on_skip_to_answer(self):
         """Test that the post quiz note is formatted correctly."""
-        concept = self.create_concept("hi", dict(fi="moi;;Moi is an informal greeting"))
+        concept = self.create_concept("hi", dict(fi="moi;;'Moi' is an informal greeting"))
         quiz = create_quizzes(FI_NL, concept).by_quiz_type("dictate").pop()
         self.assertEqual(
-            f"[{SECONDARY}]Note: Moi is an informal greeting.[/{SECONDARY}]",
+            f"[{SECONDARY}]Note: 'Moi' is an informal greeting.[/{SECONDARY}]",
             feedback_skip(quiz).split("\n")[-2],
         )
 
@@ -173,7 +173,7 @@ class FeedbackTestCase(ToistoTestCase):
         quiz = create_quizzes(FI_NL, hi).by_quiz_type("read").pop()
         feedback_text = feedback_correct(Label(NL, "hoi"), quiz, FI_NL)
         self.assertEqual(
-            CORRECT + f'[{SECONDARY}]Example: "Moi Alice!" meaning "Hoi Alice!"[/{SECONDARY}]\n',
+            CORRECT + f"[{SECONDARY}]Example: 'Moi Alice!' meaning 'Hoi Alice!'[/{SECONDARY}]\n",
             feedback_text,
         )
 
@@ -184,7 +184,7 @@ class FeedbackTestCase(ToistoTestCase):
         quiz = create_quizzes(FI_NL, hi).by_quiz_type("write").pop()
         feedback_text = feedback_correct(self.guess, quiz, FI_NL)
         self.assertEqual(
-            CORRECT + f'[{SECONDARY}]Example: "Terve Alice!" meaning "Hoi Alice!"[/{SECONDARY}]\n',
+            CORRECT + f"[{SECONDARY}]Example: 'Terve Alice!' meaning 'Hoi Alice!'[/{SECONDARY}]\n",
             feedback_text,
         )
 
@@ -194,13 +194,13 @@ class LinkifyTest(TestCase):
 
     def test_linkify(self):
         """Test the linkify method."""
-        self.assertEqual(f"[link={DICTIONARY_URL}/test]Test[/link]", linkify("Test"))
+        self.assertEqual(f"[link={DICTIONARY_URL}/test]Test[/link]", linkified("Test"))
 
     def test_linkify_multiple_words(self):
         """Test the linkify method."""
         expected_text = f"[link={DICTIONARY_URL}/test]Test[/link] [link={DICTIONARY_URL}/words]words[/link]"
-        self.assertEqual(expected_text, linkify("Test words"))
+        self.assertEqual(expected_text, linkified("Test words"))
 
     def test_punctuation(self):
         """Test that punctuation is not linked."""
-        self.assertEqual(f"[link={DICTIONARY_URL}/test]Test[/link].", linkify("Test."))
+        self.assertEqual(f"[link={DICTIONARY_URL}/test]Test[/link].", linkified("Test."))


### PR DESCRIPTION
Use single quotes when referring to questions and answers in user feedback. When feedback ends with a quoted question or answer, only add a dot if the quoted question or answer does not already end with punctuation.

Fixes #675.