### PR TITLE
Fix answer without article being marked incorrect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - Accept an initial capital letter when both the question and the answer of a quiz are in lower case. Fixes [#671](https://github.com/fniessink/toisto/issues/671).
 - Use single quotes when referring to questions and answers in user feedback. When feedback ends with a quoted question or answer, only add a period if the quoted question or answer does not already end with punctuation. Fixes [#675](https://github.com/fniessink/toisto/issues/675).
+- Allow for omitting the article when the source language is Dutch and the answer has a capital. For example, when the correct answer was "het Engels", answering "Engels" would be marked as incorrect. Fixes [#680](https://github.com/fniessink/toisto/issues/680).
 
 ### Added
 

--- a/src/toisto/model/quiz/quiz.py
+++ b/src/toisto/model/quiz/quiz.py
@@ -120,7 +120,7 @@ class Quiz:
 
     def is_correct(self, guess: Label) -> bool:
         """Return whether the guess is correct."""
-        ignore_first_upper_case = not self.question.starts_with_upper_case and not self.answer.starts_with_upper_case
+        ignore_first_upper_case = all(not label.starts_with_upper_case for label in (*self.answers, self.question))
         return match(guess.with_lower_case_first_letter if ignore_first_upper_case else guess, *self.answers)
 
     def is_question(self, guess: Label) -> bool:

--- a/tests/toisto/command/test_practice.py
+++ b/tests/toisto/command/test_practice.py
@@ -27,7 +27,7 @@ class PracticeTest(ToistoTestCase):
         self.quizzes = create_quizzes(FI_NL, self.concept).by_quiz_type("read")
 
     def practice(self, quizzes: Quizzes) -> Mock:
-        """Run the practice command and return the patch print statement."""
+        """Run the practice command and return the patched print statement."""
         config = ConfigParser()
         config.add_section("commands")
         config.set("commands", "mp3player", "mpg123")

--- a/tests/toisto/model/quiz/test_quiz.py
+++ b/tests/toisto/model/quiz/test_quiz.py
@@ -258,6 +258,13 @@ class QuizSpellingAlternativesTests(QuizTestCase):
         self.assertTrue(quiz.is_correct(answer))
         self.assertEqual((), quiz.other_answers(answer))
 
+    def test_capitalized_answer_without_article(self):
+        """Test that the article can be left out, even though the noun starts with a capital."""
+        load_spelling_alternatives(FI_NL)
+        quiz = self.create_quiz(self.concept, "englanti", ["het Engels"])
+        answer = Label(NL, "Engels")
+        self.assertTrue(quiz.is_correct(answer))
+
 
 class QuizEqualityTests(QuizTestCase):
     """Unit tests for the equality of quiz instances."""


### PR DESCRIPTION
Allow for omitting the article when the source language is Dutch and the answer has a capital. For example, when the correct answer was "het Engels", answering "Engels" would be marked as incorrect.

Fixes #680.