### PR TITLE
While quizzing colloquial language, when the user answers in the coll…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - Don't print an extra empty line between quizzes. Fixes [#719](https://github.com/fniessink/toisto/issues/719).
 - Use colors with better contrast in black on white terminals. Fixes [#720](https://github.com/fniessink/toisto/issues/720).
+- While quizzing colloquial language, when the user answers in the colloquial language instead of the standard language, add "standard" to the warning message. Fixes [#743](https://github.com/fniessink/toisto/issues/743).
 
 ### Changed
 

--- a/src/toisto/ui/text.py
+++ b/src/toisto/ui/text.py
@@ -67,6 +67,9 @@ class Feedback:
     TRY_AGAIN_IN_ANSWER_LANGUAGE: Final[str] = (
         "⚠️  Incorrect. Please try again, in [light_goldenrod2][bold]%(language)s[/bold][/light_goldenrod2]."
     )
+    TRY_AGAIN_IN_ANSWER_STANDARD_LANGUAGE: Final[str] = (
+        "⚠️  Incorrect. Please try again, in [light_goldenrod2][bold] standard %(language)s[/bold][/light_goldenrod2]."
+    )
 
     def __init__(self, quiz: Quiz, language_pair: LanguagePair) -> None:
         self.quiz = quiz
@@ -96,7 +99,9 @@ class Feedback:
     def _try_again(self, guess: Label) -> str:
         """Return the feedback when the first attempt is incorrect."""
         if self.quiz.is_question(guess) and not self.quiz.is_grammatical:
-            return self.TRY_AGAIN_IN_ANSWER_LANGUAGE % dict(language=ALL_LANGUAGES[self.quiz.answer.language])
+            colloquial = self.quiz.question.is_colloquial
+            try_again = self.TRY_AGAIN_IN_ANSWER_STANDARD_LANGUAGE if colloquial else self.TRY_AGAIN_IN_ANSWER_LANGUAGE
+            return try_again % dict(language=ALL_LANGUAGES[self.quiz.answer.language])
         return self.TRY_AGAIN
 
     def _correct_answer(self, guess: Label) -> str:

--- a/tests/toisto/command/test_practice.py
+++ b/tests/toisto/command/test_practice.py
@@ -97,6 +97,17 @@ class PracticeTest(ToistoTestCase):
         quizzes = create_quizzes(self.language_pair, self.concept).by_quiz_type("dictate")
         self.assert_printed(Feedback.TRY_AGAIN_IN_ANSWER_LANGUAGE % dict(language="Finnish"), self.practice(quizzes))
 
+    @patch("builtins.input", Mock(return_value="jätski\n"))
+    def test_answer_with_question_colloquial(self):
+        """Test that the language to answer is stressed, when the user answers the quiz with the wrong language."""
+        concept = self.create_concept("ice cream", dict(fi=["jäätelö", "jätski*"], nl="het ijsje"))
+        dictate_quizzes = create_quizzes(self.language_pair, concept).by_quiz_type("dictate")
+        colloquial_dictate_quizzes = Quizzes(quiz for quiz in dictate_quizzes if quiz.question == Label(FI, "jätski*"))
+        self.assert_printed(
+            Feedback.TRY_AGAIN_IN_ANSWER_STANDARD_LANGUAGE % dict(language="Finnish"),
+            self.practice(colloquial_dictate_quizzes),
+        )
+
     @patch("builtins.input", Mock(return_value="talo\n"))
     def test_answer_with_question_grammar_quiz(self):
         """Test that the language to answer is not stressed, when the user answers a grammar quiz with the question."""


### PR DESCRIPTION
…oquial language instead of the standard language, add "standard" to the warnig message.

Fixes #743.