### PR TITLE
Languages in Finnish should be lower case, but Toisto did not enforce…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 
 - What were called homonyms previously, are actually homographs: labels that are spelled the same.
+- Languages in Finnish should be lower case, but Toisto did not enforce this. Fixes [#736](https://github.com/fniessink/toisto/issues/736).
 
 ### Added
 

--- a/src/toisto/model/language/label.py
+++ b/src/toisto/model/language/label.py
@@ -104,11 +104,6 @@ class Label:
         return Label(self.language, self._value.split(self.NOTE_SEP)[0])
 
     @property
-    def with_lower_case_first_letter(self) -> Label:
-        """Return the label with the first letter lower cased."""
-        return Label(self.language, self._value[0].lower() + self._value[1:])
-
-    @property
     def with_upper_case_first_letter(self) -> Label:
         """Return the label with the first letter upper cased."""
         return Label(self.language, self._value[0].upper() + self._value[1:])
@@ -132,11 +127,6 @@ class Label:
     def starts_with_upper_case(self) -> bool:
         """Return whether the label starts with an upper case letter."""
         return self._value[0].isupper()
-
-    @property
-    def has_upper_case(self) -> bool:
-        """Return whether the label has one or more upper case letters."""
-        return any(char.isupper() for char in self._value)
 
     @property
     def ends_with_punctuation(self) -> bool:

--- a/src/toisto/model/quiz/quiz.py
+++ b/src/toisto/model/quiz/quiz.py
@@ -133,8 +133,6 @@ class Quiz:
     def is_correct(self, guess: Label, language_pair: LanguagePair) -> bool:
         """Return whether the guess is correct."""
         answers = self.answers
-        if all(not label.has_upper_case for label in (*answers, self.question)):
-            guess = guess.with_lower_case_first_letter
         if guess.language == language_pair.source:
             guess = guess.lower_case
             answers = answers.lower_case

--- a/tests/toisto/model/quiz/test_quiz.py
+++ b/tests/toisto/model/quiz/test_quiz.py
@@ -59,17 +59,30 @@ class QuizTest(QuizTestCase):
         """Test that a lower case answer to an upper case question is correct, if source language == answer language."""
         self.assertTrue(self.quiz.is_correct(Label(NL, "engels"), self.language_pair))
 
-    def test_is_not_correct_due_to_upper_case_answer(self):
-        """Test that a lower case answer is incorrect when the answer should be upper case."""
+    def test_case_matches_for_read_and_intepret_quizzes(self):
+        """Test that a lower case answer is incorrect when the answer should be upper case, and vice versa."""
         concept = self.create_concept("finnish", {})
-        quiz = self.create_quiz(concept, "suomi", ["het Fins"], "read", language_pair=FI_NL)
-        self.assertTrue(quiz.is_correct(Label(NL, "fins"), FI_NL), quiz)
-        quiz = self.create_quiz(concept, "het Fins", ["suomi"], "read", language_pair=NL_FI)
-        self.assertTrue(quiz.is_correct(Label(FI, "Suomi"), NL_FI))
-        quiz = self.create_quiz(concept, "suomi", ["het Fins"], "listen", language_pair=FI_NL)
-        self.assertFalse(quiz.is_correct(Label(NL, "Suomi"), FI_NL))
-        quiz = self.create_quiz(concept, "het Fins", ["suomi"], "listen", language_pair=NL_FI)
-        self.assertTrue(quiz.is_correct(Label(FI, "Suomi"), NL_FI))
+
+        for quiz_type in ("read", "interpret"):
+            quiz = self.create_quiz(concept, "suomi", ["het Fins"], quiz_type, language_pair=FI_NL)
+            self.assertTrue(quiz.is_correct(Label(NL, "Fins"), FI_NL), quiz)
+            self.assertTrue(quiz.is_correct(Label(NL, "fins"), FI_NL), quiz)
+
+            quiz = self.create_quiz(concept, "het Fins", ["suomi"], quiz_type, language_pair=NL_FI)
+            self.assertTrue(quiz.is_correct(Label(FI, "Suomi"), NL_FI))
+            self.assertTrue(quiz.is_correct(Label(FI, "suomi"), NL_FI))
+
+    def test_case_matches_for_listen_quizzes(self):
+        """Test that a lower case answer is incorrect when the answer should be upper case, and vice versa."""
+        concept = self.create_concept("finnish", {})
+
+        quiz = self.create_quiz(concept, "suomi", ["suomi"], "listen", language_pair=FI_NL)
+        self.assertFalse(quiz.is_correct(Label(FI, "Suomi"), FI_NL))
+        self.assertTrue(quiz.is_correct(Label(FI, "suomi"), FI_NL))
+
+        quiz = self.create_quiz(concept, "het Fins", ["het Fins"], "listen", language_pair=NL_FI)
+        self.assertFalse(quiz.is_correct(Label(NL, "fins"), NL_FI))
+        self.assertTrue(quiz.is_correct(Label(NL, "Fins"), NL_FI))
 
     def test_get_answer(self):
         """Test that the answer is returned."""


### PR DESCRIPTION
… this.

Fixes #736.