### PR TITLE
There would be two spaces between ⚠️ and "Incorrect...".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 
 - Some quizzes would not be created if nouns are invariant in one language, but not in another (like "sheep" or "means of transportation"). Fixes [#438](https://github.com/fniessink/toisto/issues/438).
+- There would be two spaces between ⚠️ and "Incorrect...". Fixes [#775](https://github.com/fniessink/toisto/issues/775).
 
 ### Added
 

--- a/src/toisto/ui/text.py
+++ b/src/toisto/ui/text.py
@@ -65,12 +65,12 @@ class Feedback:
 
     CORRECT: Final[str] = "✅ Correct.\n"
     INCORRECT: Final[str] = "❌ Incorrect. "
-    TRY_AGAIN: Final[str] = "⚠️  Incorrect. Please try again."
+    TRY_AGAIN: Final[str] = "⚠️ Incorrect. Please try again."
     TRY_AGAIN_IN_ANSWER_LANGUAGE: Final[str] = (
-        "⚠️  Incorrect. Please try again, in [light_goldenrod2][bold]%(language)s[/bold][/light_goldenrod2]."
+        "⚠️ Incorrect. Please try again, in [light_goldenrod2][bold]%(language)s[/bold][/light_goldenrod2]."
     )
     TRY_AGAIN_IN_ANSWER_STANDARD_LANGUAGE: Final[str] = (
-        "⚠️  Incorrect. Please try again, in [light_goldenrod2][bold] standard %(language)s[/bold][/light_goldenrod2]."
+        "⚠️ Incorrect. Please try again, in [light_goldenrod2][bold] standard %(language)s[/bold][/light_goldenrod2]."
     )
 
     def __init__(self, quiz: Quiz, language_pair: LanguagePair) -> None:


### PR DESCRIPTION
Fixes #775.