### PR TITLE
Don't show an example multiple times if it has multiple meanings.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 
 - Some quizzes would not be created if nouns are invariant in one language, but not in another (like "sheep" or "means of transportation"). Fixes [#438](https://github.com/fniessink/toisto/issues/438).
+- Don't show an example multiple times if it has multiple meanings. Fixes [#774](https://github.com/fniessink/toisto/issues/774).
 - There would be two spaces between ⚠️ and "Incorrect...". Fixes [#775](https://github.com/fniessink/toisto/issues/775).
 
 ### Added

--- a/src/toisto/ui/text.py
+++ b/src/toisto/ui/text.py
@@ -3,7 +3,6 @@
 import sys
 from collections.abc import Callable, Sequence
 from configparser import ConfigParser
-from itertools import zip_longest
 from typing import Final, cast
 
 from rich.console import Console
@@ -153,9 +152,8 @@ class Feedback:
         for example in self.quiz.concept.get_related_concepts("example"):
             example_labels = example.labels(self.language_pair.target).first_non_generated_spelling_alternatives
             example_meanings = example.labels(self.language_pair.source).first_non_generated_spelling_alternatives
-            shorter = example_labels if len(example_labels) < len(example_meanings) else example_meanings
-            for label, meaning in zip_longest(example_labels, example_meanings, fillvalue=shorter[-1]):
-                examples.append(f"{quoted(str(label))} meaning {quoted(str(meaning))}")
+            enumerated_meanings = enumerated(*[quoted(str(meaning)) for meaning in example_meanings])
+            examples.extend(f"{quoted(str(label))} meaning {enumerated_meanings}" for label in example_labels)
         return bulleted_list("Example", examples)
 
 

--- a/tests/toisto/command/test_practice.py
+++ b/tests/toisto/command/test_practice.py
@@ -224,8 +224,8 @@ class PracticeTest(ToistoTestCase):
         expected_argument = (
             f"{Feedback.CORRECT}[{SECONDARY}]Meaning '{linkified('pöytälamppu')}' and "
             f"'{linkified('pöytävalaisin')}'.[/{SECONDARY}]\n"
-            f"[{SECONDARY}]Examples:\n- 'Ik zoek een tafellamp.' meaning 'Minä etsin pöytälamppua.'\n"
-            f"- 'Ik zoek een tafellamp.' meaning 'Minä etsin pöytävalaisinta.'[/{SECONDARY}]\n"
+            f"[{SECONDARY}]Example: 'Ik zoek een tafellamp.' meaning 'Minä etsin pöytälamppua.' and "
+            f"'Minä etsin pöytävalaisinta.'[/{SECONDARY}]\n"
         )
         self.assert_printed(expected_argument, self.practice(quizzes))
 

--- a/tests/toisto/ui/test_text.py
+++ b/tests/toisto/ui/test_text.py
@@ -207,6 +207,18 @@ class FeedbackTestCase(ToistoTestCase):
             feedback(Evaluation.CORRECT, self.guess),
         )
 
+    def test_post_quiz_example_with_multiple_meanings(self):
+        """Test that the post quiz example is not repeated if an examples has multiple meanings."""
+        hi = self.create_concept("hi", dict(nl="hoi", fi="terve", example="hi alice"))
+        self.create_concept("hi alice", dict(fi="Terve Alice!", nl=["Hoi Alice!", "Hallo Alice!"]))
+        quiz = create_quizzes(FI_NL, hi).by_quiz_type(WRITE).pop()
+        feedback = Feedback(quiz, FI_NL)
+        self.assertEqual(
+            Feedback.CORRECT
+            + f"[{SECONDARY}]Example: 'Terve Alice!' meaning 'Hoi Alice!' and 'Hallo Alice!'[/{SECONDARY}]\n",
+            feedback(Evaluation.CORRECT, self.guess),
+        )
+
 
 class LinkifyTest(TestCase):
     """Unit tests for the linkify method."""


### PR DESCRIPTION
Fixes #774.