### PR TITLE
Don't include generated spelling alternatives in the progress table.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - There would be two spaces between ⚠️ and "Incorrect...". Fixes [#775](https://github.com/fniessink/toisto/issues/775).
 - Finnish "entä" is not a synonym of "ja". Fixes [#778](https://github.com/fniessink/toisto/issues/778).
 - Use the terms 'feminine' and 'masculine' instead of 'female' and 'male' for grammatical gender. Fixes [#789](https://github.com/fniessink/toisto/issues/789).
+- Don't include generated spelling alternatives (for example, "it's" for "it is") in the progress table. Fixes [#794](https://github.com/fniessink/toisto/issues/794).
 
 ### Added
 

--- a/src/toisto/command/show_progress.py
+++ b/src/toisto/command/show_progress.py
@@ -46,7 +46,7 @@ def show_progress(progress: Progress, sort: SortColumn) -> None:
             str(quiz.question),
             quiz.question.language,
             quiz.answer.language,
-            "\n".join(quiz.answers.as_strings),
+            " - ".join(quiz.non_generated_answers.as_strings),
             str(retention.count),
             format_duration(retention.length) if retention.length else "",
             format_datetime(skip) if skip and skip > datetime.now() else "",


### PR DESCRIPTION
Fixes #794.