### PR TITLE
Don't say "Please try again, in standard (answer language)." when it …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Finnish "entä" is not a synonym of "ja". Fixes [#778](https://github.com/fniessink/toisto/issues/778).
 - Use the terms 'feminine' and 'masculine' instead of 'female' and 'male' for grammatical gender. Fixes [#789](https://github.com/fniessink/toisto/issues/789).
 - Don't include generated spelling alternatives (for example, "it's" for "it is") in the progress table. Fixes [#794](https://github.com/fniessink/toisto/issues/794).
+- Don't say "Please try again, in standard (answer language)." when it is the question language that is colloquial. Fixes [#799](https://github.com/fniessink/toisto/issues/799).
 
 ### Added
 

--- a/src/toisto/model/quiz/quiz.py
+++ b/src/toisto/model/quiz/quiz.py
@@ -165,6 +165,11 @@ class Quizzes(set[Quiz]):
             quizzes |= self.by_concept(example)
         return quizzes
 
+    @property
+    def colloquial(self) -> Quizzes:
+        """Return the colloquial quizzes."""
+        return self.__class__(quiz for quiz in self if quiz.question.is_colloquial)
+
     def by_quiz_type(self, quiz_type: QuizType | type[QuizType]) -> Quizzes:
         """Return the quizzes of the specified type."""
         return self.__class__(quiz for quiz in self if quiz.has_quiz_type(quiz_type))

--- a/src/toisto/ui/text.py
+++ b/src/toisto/ui/text.py
@@ -97,8 +97,8 @@ class Feedback:
     def _try_again(self, guess: Label) -> str:
         """Return the feedback when the first attempt is incorrect."""
         if self.quiz.is_question(guess) and not self.quiz.has_quiz_type(GrammaticalQuizType):
-            colloquial = self.quiz.question.is_colloquial
-            try_again = self.TRY_AGAIN_IN_ANSWER_STANDARD_LANGUAGE if colloquial else self.TRY_AGAIN_IN_ANSWER_LANGUAGE
+            standard = self.quiz.question.is_colloquial and self.quiz.question.language == self.quiz.answer.language
+            try_again = self.TRY_AGAIN_IN_ANSWER_STANDARD_LANGUAGE if standard else self.TRY_AGAIN_IN_ANSWER_LANGUAGE
             return try_again % dict(language=ALL_LANGUAGES[self.quiz.answer.language])
         return self.TRY_AGAIN
 

--- a/tests/toisto/command/test_practice.py
+++ b/tests/toisto/command/test_practice.py
@@ -8,7 +8,7 @@ from toisto.model.language.label import Label
 from toisto.model.quiz.progress import Progress
 from toisto.model.quiz.quiz import Quizzes
 from toisto.model.quiz.quiz_factory import create_quizzes
-from toisto.model.quiz.quiz_type import DICTATE, PLURAL, READ, WRITE
+from toisto.model.quiz.quiz_type import DICTATE, INTERPRET, PLURAL, READ, WRITE
 from toisto.persistence.config import default_config
 from toisto.ui.dictionary import linkified
 from toisto.ui.text import DONE, Feedback, ProgressUpdate, console
@@ -95,15 +95,21 @@ class PracticeTest(ToistoTestCase):
         self.assert_printed(Feedback.TRY_AGAIN_IN_ANSWER_LANGUAGE % dict(language="Finnish"), self.practice(quizzes))
 
     @patch("builtins.input", Mock(return_value="jätski\n"))
-    def test_answer_with_question_colloquial(self):
+    def test_colloquial_answer_when_question_colloquial(self):
         """Test that the language to answer is stressed, when the user answers the quiz with the wrong language."""
         concept = self.create_concept("ice cream", dict(fi=["jäätelö", "jätski*"], nl="het ijsje"))
-        dictate_quizzes = create_quizzes(self.language_pair, concept).by_quiz_type(DICTATE)
-        colloquial_dictate_quizzes = Quizzes(quiz for quiz in dictate_quizzes if quiz.question == Label(FI, "jätski*"))
+        quizzes = create_quizzes(self.language_pair, concept).by_quiz_type(DICTATE).colloquial
         self.assert_printed(
             Feedback.TRY_AGAIN_IN_ANSWER_STANDARD_LANGUAGE % dict(language="Finnish"),
-            self.practice(colloquial_dictate_quizzes),
+            self.practice(quizzes),
         )
+
+    @patch("builtins.input", Mock(return_value="jäätelö\n"))
+    def test_standard_language_answer_when_question_colloquial(self):
+        """Test that the language to answer is stressed, when the user answers the quiz with the wrong language."""
+        concept = self.create_concept("ice cream", dict(fi=["jäätelö", "jätski*"], nl="het ijsje"))
+        quizzes = create_quizzes(self.language_pair, concept).by_quiz_type(INTERPRET).colloquial
+        self.assert_printed(Feedback.TRY_AGAIN_IN_ANSWER_LANGUAGE % dict(language="Dutch"), self.practice(quizzes))
 
     @patch("builtins.input", Mock(return_value="talo\n"))
     def test_answer_with_question_grammar_quiz(self):


### PR DESCRIPTION
…is the question language that is colloquial.

Fixes #799.