### PR TITLE
Extract a method for determining the home folder.

### DIFF
--- a/src/toisto/metadata.py
+++ b/src/toisto/metadata.py
@@ -8,7 +8,7 @@ from typing import Final
 
 import requests
 
-from toisto.model.language import EN, FI, NL, Language
+from toisto.model.language import EN, FI, NL
 from toisto.tools import first
 
 _metadata = metadata("Toisto")
@@ -27,11 +27,6 @@ BUILT_IN_CONCEPT_JSON_FILES: Final = sorted((_data_folder / "concepts").glob("**
 _languages_folder = _data_folder / "languages"
 LANGUAGES_FILE: Final = _languages_folder / "iana-language-subtag-registry.txt"
 SPELLING_ALTERNATIVES_FILE: Final = _languages_folder / "spelling_alternatives.json"
-
-
-def get_progress_filepath(target_language: Language) -> Path:
-    """Return the filename of the progress file for the specified target language."""
-    return Path.home() / f".{NAME.lower()}-progress-{target_language}.json"
 
 
 def latest_version() -> str | None:

--- a/src/toisto/persistence/config.py
+++ b/src/toisto/persistence/config.py
@@ -11,6 +11,8 @@ from typing import Final, NoReturn
 
 from toisto.model.language.iana_language_subtag_registry import ALL_LANGUAGES
 
+from .folder import home
+
 # The schema for the config file. Top-level keys are sections, values are a dict per option with the key being the
 # option name and the value being an option consisting of the option quantifier, the allowed option values, and a
 # function evaluating the validity of the option value.
@@ -49,7 +51,7 @@ CONFIG_SCHEMA: Final[dict[str, dict[str, Option]]] = dict(
         progress_update=Option(Quantifier.INTEGER, ["0", "1", "2", "3", "..."], lambda value: value.isdigit(), "0"),
     ),
 )
-CONFIG_FILENAME = Path("~/.toisto.cfg").expanduser()
+CONFIG_FILENAME = home() / ".toisto.cfg"
 
 
 class ConfigSchemaValidator:

--- a/src/toisto/persistence/folder.py
+++ b/src/toisto/persistence/folder.py
@@ -1,0 +1,8 @@
+"""Platform independent way get the home folder."""
+
+from pathlib import Path
+
+
+def home() -> Path:
+    """Return the home folder."""
+    return Path.home()

--- a/src/toisto/persistence/progress.py
+++ b/src/toisto/persistence/progress.py
@@ -1,12 +1,19 @@
 """Store and load progress data."""
 
 from argparse import ArgumentParser
+from pathlib import Path
 
-from ..metadata import NAME, get_progress_filepath
+from ..metadata import NAME
 from ..model.language import Language
 from ..model.quiz.progress import Progress
 from ..model.quiz.quiz import Quizzes
+from .folder import home
 from .json_file import dump_json, load_json
+
+
+def get_progress_filepath(target_language: Language) -> Path:
+    """Return the filename of the progress file for the specified target language."""
+    return home() / f".{NAME.lower()}-progress-{target_language}.json"
 
 
 def load_progress(target_language: Language, quizzes: Quizzes, argument_parser: ArgumentParser) -> Progress:

--- a/tests/toisto/persistence/test_progress.py
+++ b/tests/toisto/persistence/test_progress.py
@@ -3,12 +3,11 @@
 from argparse import ArgumentParser
 from unittest.mock import MagicMock, Mock, patch
 
-from toisto.metadata import get_progress_filepath
 from toisto.model.language import FI, Language
 from toisto.model.quiz.progress import Progress
 from toisto.model.quiz.quiz import Quizzes
 from toisto.model.quiz.retention import Retention
-from toisto.persistence.progress import load_progress, save_progress
+from toisto.persistence.progress import get_progress_filepath, load_progress, save_progress
 
 from ...base import ToistoTestCase
 


### PR DESCRIPTION
To prepare for supporting a-Shell (which has a non-standard home folder) we have to stop using ~ or Path.home() to get to the user's home folder.