### PR TITLE
When showing the help information for the practice command (`toisto p…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Toisto will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- When showing the help information for the practice command (`toisto practice --help`), don't show concepts that are sentences and don't show concepts that have a hypernym. Closes [#811](https://github.com/fniessink/toisto/issues/811).
+
 ## 0.24.0 - 2024-09-01
 
 ### Added

--- a/src/toisto/model/language/concept.py
+++ b/src/toisto/model/language/concept.py
@@ -120,7 +120,7 @@ class Concept:
                 for concept in self.get_all_concepts()
                 if self in concept.get_related_concepts(inverted_relation, self, *visited_concepts)
             )
-        related_concepts = self.get_concepts(*self._related_concepts[relation])
+        related_concepts = self.get_concepts(*self._related_concepts.get(relation, []))
         if relation not in get_args(RecursiveConceptRelation):
             return related_concepts
         related_concepts_list = list(related_concepts)
@@ -238,6 +238,17 @@ class Concept:
         concept_ids_of_roots = self._roots.get(language, ()) if isinstance(self._roots, dict) else self._roots
         direct_roots = self.get_concepts(*concept_ids_of_roots)
         return Concepts(direct_roots + direct_roots.roots(language))
+
+    @property
+    def is_complete_sentence(self) -> bool:
+        """Return whether this concept is a complete sentence."""
+        if self._labels:
+            return self._labels[0].is_complete_sentence
+        if self._meanings:
+            return self._meanings[0].is_complete_sentence
+        if self._constituents:
+            return self.get_concepts(self._constituents[0])[0].is_complete_sentence
+        return False
 
 
 class Concepts(tuple[Concept, ...]):

--- a/src/toisto/ui/cli.py
+++ b/src/toisto/ui/cli.py
@@ -42,7 +42,10 @@ def check_language(language: str) -> str:
 
 def add_concept_argument(parser: ArgumentParser, concepts: set[Concept]) -> None:
     """Add the concept argument."""
-    concept_ids = sorted(concept.concept_id for concept in concepts)
+    concept_ids = sorted(
+        concept.concept_id for concept in concepts
+        if not concept.is_complete_sentence and not concept.get_related_concepts("hypernym")
+    )
     parser.add_argument(
         "concepts",
         metavar="{concept}",

--- a/tests/toisto/model/language/test_concept.py
+++ b/tests/toisto/model/language/test_concept.py
@@ -100,3 +100,16 @@ class ConceptTest(ToistoTestCase):
         greece = self.create_concept("greece", {"fi": "Kreikki"})
         greek = self.create_concept("greek", {"fi": "kreikki;;In Finnish, the names of languages are not capitalized"})
         self.assertEqual((greece,), greek.get_capitonyms(Label(FI, "kreikki")))
+
+    def test_is_sentence(self):
+        """Test the is-sentence property."""
+        self.assertFalse(self.create_concept("sea", {"en": "sea"}).is_complete_sentence)
+        self.assertFalse(self.create_concept("greece", {"en": "Greece"}).is_complete_sentence)
+        self.assertTrue(self.create_concept("hi", {"fi": "Hei!"}).is_complete_sentence)
+        self.assertTrue(self.create_concept("meaning only", {"fi": "(Hei!)"}).is_complete_sentence)
+        self.assertFalse(self.create_concept("involves only", {"involves": ["other concept"]}).is_complete_sentence)
+        composite_concept = self.create_concept(
+            "the house is big",
+            {"singular": {"en": "The house is big."}, "plural": {"en": "The houses are big."}},
+        )
+        self.assertTrue(composite_concept.is_complete_sentence)


### PR DESCRIPTION
…ractice --help`), don't show concepts that are sentences.

Closes #811.