### PR TITLE
Save progress after every quiz.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 
 - Accept both the masculine and the feminine third person singular when asking for the translation of the third person singular of a Finnish verb. Fixes [#826](https://github.com/fniessink/toisto/issues/826).
+- On the iPhone, iOS may kill a-Shell and thus Toisto, causing progress to be lost. Save progress after every quiz to prevent the loss of progress. Fixes [#834](https://github.com/fniessink/toisto/issues/834).
 
 ### Changed
 

--- a/src/toisto/command/practice.py
+++ b/src/toisto/command/practice.py
@@ -63,11 +63,10 @@ def practice(
     try:
         while quiz := progress.next_quiz():
             do_quiz(write_output, language_pair, quiz, progress, speech)
+            save_progress(progress)
             with dramatic.output.at_speed(120):
                 # Turn off highlighting to work around https://github.com/treyhunner/dramatic/issues/8:
                 write_output(progress_update(), end="", highlight=False)
         write_output(DONE)
     except (KeyboardInterrupt, EOFError):
         write_output()  # Make sure the shell prompt is displayed on a new line
-    finally:
-        save_progress(progress)


### PR DESCRIPTION
On the iPhone, iOS may kill a-Shell and thus Toisto, causing progress to be lost. Save progress after every quiz to prevent the loss of progress.

Fixes #834.