### PR TITLE
Generate hints for holonyms that are homographs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Toisto will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Automatically generate a hint if one concept is a holonym of another concept with the same label, meaning they are homographs. An example is 'puu' in Finnish, which can mean both 'wood' and' 'tree' in English. Closes [#843](https://github.com/fniessink/toisto/issues/843).
+
 ## 0.25.0 - 2024-09-24
 
 ### Fixed

--- a/src/concepts/nouns/tree.json
+++ b/src/concepts/nouns/tree.json
@@ -1,5 +1,6 @@
 {
     "tree": {
+        "hypernym": "plant",
         "singular": {
             "en": "tree",
             "fi": "puu",

--- a/src/concepts/nouns/wood.json
+++ b/src/concepts/nouns/wood.json
@@ -1,5 +1,6 @@
 {
     "wood": {
+        "holonym": "tree",
         "en": "wood",
         "fi": "puu",
         "nl": "het hout"

--- a/src/toisto/model/quiz/quiz.py
+++ b/src/toisto/model/quiz/quiz.py
@@ -149,8 +149,10 @@ class Quiz:
         """Return the note(s) to be shown as part of the question, if the question has one or more homonyms."""
         if self.concept.same_base_concept(*homonyms):
             return self.concept.grammatical_differences(*homonyms)
-        hypernyms = self.concept.get_related_concepts("hypernym")
-        return [hypernym.concept_id for hypernym in hypernyms[:1]]
+        if hypernyms := self.concept.get_related_concepts("hypernym"):
+            return [hypernym.concept_id for hypernym in hypernyms[:1]]
+        holonyms = self.concept.get_related_concepts("holonym")
+        return [f"part of {holonym.concept_id}" for holonym in holonyms]
 
 
 class Quizzes(set[Quiz]):

--- a/src/toisto/model/quiz/quiz_type.py
+++ b/src/toisto/model/quiz/quiz_type.py
@@ -141,7 +141,8 @@ class WriteQuizType(TranslationQuizType):
 
     def question_notes(self, question: Label, answers: Labels, *homonym_notes: str) -> list[str]:  # noqa: ARG002
         """Return the note to be shown before the quiz has been answered."""
-        return [question_note] if (question_note := first(answers).question_note) else []
+        notes = [question_note] if (question_note := first(answers).question_note) else []
+        return notes + list(homonym_notes)
 
     def answer_notes(self, question: Label, answers: Labels) -> Sequence[str]:  # noqa: ARG002
         """Return the notes to be shown after the quiz has been answered."""

--- a/tests/toisto/model/quiz/test_quiz.py
+++ b/tests/toisto/model/quiz/test_quiz.py
@@ -342,11 +342,22 @@ class QuizInstructionTest(QuizTestCase):
         quiz = self.create_quiz(second_person_singular, "you read", ["jij leest"], INTERPRET)
         self.assertEqual("Listen and write in Dutch (present tense; singular)", quiz.instruction)
 
+    def test_homographs_get_an_automatic_note_based_on_the_holonym(self):
+        """Test that homographs get an automatic note based on the holonym."""
+        self.language_pair = NL_FI
+        self.create_concept("tree", {"fi": "puu", "nl": "de boom"})
+        wood = self.create_concept("wood", {"holonym": "tree", "fi": "puu", "nl": "het hout"})
+        write_quiz = self.create_quiz(wood, "puu", ["het hout"], WRITE)
+        self.assertEqual("Translate into Dutch (part of tree)", write_quiz.instruction)
+        self.language_pair = FI_NL
+        dictate_quiz = self.create_quiz(wood, "puu", ["het hout"], INTERPRET)
+        self.assertEqual("Listen and write in Dutch (part of tree)", dictate_quiz.instruction)
+
     def test_capitonyms_get_an_automatic_note_based_on_the_hypernym(self):
         """Test that capitonyms get an automatic note based on the hypernym, for listening quizzes."""
         self.language_pair = FI_NL
-        self.create_concept("greece", {"fi": "Kreikka", "nl": "Griekenland"})  # Create the capitonym of greek
-        self.create_concept("language", {})  # Create the hypernym of Indo-Wuropean language
+        self.create_concept("greece", {"fi": "Kreikka", "nl": "Griekenland"})
+        self.create_concept("language", {})
         greek = self.create_concept("greek", {"hypernym": "language", "fi": "kreikka", "nl": "Grieks"})
         quiz = self.create_quiz(greek, "kreikka", ["Grieks"], DICTATE)
         self.assertEqual("Listen and write in Finnish (language)", quiz.instruction)


### PR DESCRIPTION
Automatically generate a hint if one concept is a holonym of another concept with the same label, meaning they are homographs. An example is 'puu' in Finnish, which can mean both 'wood' and' 'tree' in English.

Closes #843.