### PR TITLE
Use a uuid as part of the progress filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,7 +291,7 @@ Toisto supports quiz types such as:
 
 See [the complete list of quiz types](docs/software.md#quizzes).
 
-When you stop the program (hit Ctrl-C or Ctrl-D), progress is saved in a file named `.toisto-progress-{target language}.json` in your home folder, for example `.toisto-progress-fi.json`.
+When you stop the program (hit Ctrl-C or Ctrl-D), progress is saved in a file named `.toisto-{uuid}-progress-{target language}.json` in your home folder, for example `.toisto-221b69f2-83ef-11ef-abc8-2642a2aed6c5-progress-fi.json`.
 
 ## Further documentation
 

--- a/src/toisto/app.py
+++ b/src/toisto/app.py
@@ -41,7 +41,7 @@ class CLI:
         concepts = self.build_in_concepts | self.loader.load_concepts(*self.args.file)
         filtered_concepts = filter_concepts(concepts, self.args.concepts, target_language, self.argument_parser)
         quizzes = create_quizzes(self.language_pair, *filtered_concepts)
-        return load_progress(target_language, quizzes, self.argument_parser)
+        return load_progress(target_language, quizzes, self.argument_parser, self.config["identity"]["uuid"])
 
 
 def main() -> None:

--- a/src/toisto/command/practice.py
+++ b/src/toisto/command/practice.py
@@ -60,10 +60,11 @@ def practice(
     """Practice a language."""
     progress_update = ProgressUpdate(progress, progress_update_frequency)
     speech = Speech(config)
+    uuid = config["identity"]["uuid"]
     try:
         while quiz := progress.next_quiz():
             do_quiz(write_output, language_pair, quiz, progress, speech)
-            save_progress(progress)
+            save_progress(progress, uuid)
             with dramatic.output.at_speed(120):
                 # Turn off highlighting to work around https://github.com/treyhunner/dramatic/issues/8:
                 write_output(progress_update(), end="", highlight=False)

--- a/src/toisto/persistence/config.py
+++ b/src/toisto/persistence/config.py
@@ -8,6 +8,7 @@ from enum import Enum
 from io import StringIO
 from pathlib import Path
 from typing import Final, NoReturn
+from uuid import uuid1
 
 from toisto.model.language.iana_language_subtag_registry import ALL_LANGUAGES
 from toisto.tools import platform
@@ -49,6 +50,7 @@ CONFIG_SCHEMA: Final[dict[str, dict[str, Option] | list[str]]] = dict(
     practice=dict(
         progress_update=Option(Quantifier.INTEGER, ["0", "1", "2", "3", "..."], lambda value: value.isdigit(), "0"),
     ),
+    identity=dict(uuid=Option(Quantifier.ANY, default_value=str(uuid1()))),
     files=[],
 )
 CONFIG_FILENAME = home() / ".toisto.cfg"


### PR DESCRIPTION
Use a uuid as part of the progress filename so that different devices use different filenames for the progress save file. Prepares for sharing progress between devices.

Prepares for #816.