### PR TITLE
Don't use concept id in quiz repr.

### DIFF
--- a/docs/software.md
+++ b/docs/software.md
@@ -1013,6 +1013,22 @@ Each entry in the file is the progress of one specific quiz. The key denotes the
 
 ```json
 {
+    "nl:fi:lezen:lukea:translate": {
+        "count": 2
+    },
+    "nl:fi:het oog:silmä:translate": {
+        "start": "2023-02-25T17:34:37",
+        "end": "2023-02-25T17:35:37",
+        "skip_until": "2023-02-26T17:40:37",
+        "count": 3
+    }
+}
+```
+
+The key format was changed in Toisto v0.28 to not include the concept identifier. This allows for changing the concept identifier without invalidating the user's progress on quizzes for that concept. Whenever Toisto reads a progress file with keys in the old format, it converts the keys the new format, where possible (it can only do so for concepts the user wants to practice). The old format looks as follows:
+
+```json
+{
     "to read:nl:fi:lezen:translate": {
         "count": 2
     },

--- a/src/toisto/model/quiz/quiz.py
+++ b/src/toisto/model/quiz/quiz.py
@@ -48,6 +48,12 @@ class Quiz:
     @cached_property
     def key(self) -> str:
         """Return a string version of the quiz that can be used as key in the progress dict."""
+        question = self._question.first_spelling_alternative
+        return f"{self.question.language}:{self.answer.language}:{question}:{self.answer}:{self.quiz_type.action}"
+
+    @property
+    def old_key(self) -> str:
+        """Return a string version of the quiz as it was used before."""
         concept_id = self.concept.base_concept.concept_id
         question = self._question.first_spelling_alternative
         return f"{concept_id}:{self.question.language}:{self.answer.language}:{question}:{self.quiz_type.action}"

--- a/src/toisto/persistence/progress.py
+++ b/src/toisto/persistence/progress.py
@@ -39,6 +39,7 @@ def load_progress(
         if other_progress_filepath != progress_filepath
     ]
     update_progress_dict(progress_dict, *other_progress_dicts)
+    update_quiz_keys(progress_dict, quizzes)
     return Progress(target_language, quizzes, progress_dict)
 
 
@@ -77,3 +78,11 @@ def update_progress_dict(progress_dict: ProgressDict, *progress_dicts: ProgressD
                     progress_dict[key]["skip_until"] = max(current_skip_until, other_skip_until)
                 else:
                     progress_dict[key] = {"skip_until": other_skip_until}
+
+
+def update_quiz_keys(progress_dict: ProgressDict, quizzes: Quizzes) -> None:
+    """Replace old quiz keys with new keys in the progress dict."""
+    for quiz in quizzes:
+        if quiz.old_key in progress_dict:
+            progress_dict[quiz.key] = progress_dict[quiz.old_key]
+            del progress_dict[quiz.old_key]

--- a/tests/toisto/model/quiz/test_quiz.py
+++ b/tests/toisto/model/quiz/test_quiz.py
@@ -72,7 +72,11 @@ class QuizTest(QuizTestCase):
 
     def test_repr(self):
         """Test the repr() function."""
-        self.assertEqual("english:fi:nl:englanti:read", repr(self.quiz))
+        self.assertEqual("fi:nl:englanti:Engels:read", repr(self.quiz))
+
+    def test_old_key(self):
+        """Test the old key property."""
+        self.assertEqual("english:fi:nl:englanti:read", self.quiz.old_key)
 
     def test_is_correct(self):
         """Test a correct guess."""
@@ -485,9 +489,9 @@ class QuizEqualityTests(QuizTestCase):
         """Test that quizzes are not equal if only their questions differ."""
         self.assertNotEqual(self.copy_quiz(self.quiz, question="Saksa"), self.quiz)
 
-    def test_equal_with_different_answers(self):
-        """Test that quizzes are equal if only their answers differ."""
-        self.assertEqual(self.copy_quiz(self.quiz, answers=["Duits"]), self.quiz)
+    def test_not_equal_with_different_answers(self):
+        """Test that quizzes are not equal if only their answers differ."""
+        self.assertNotEqual(self.copy_quiz(self.quiz, answers=["Duits"]), self.quiz)
 
     def test_not_equal_with_different_quiz_types(self):
         """Test that quizzes are not equal if only their quiz types differ."""
@@ -497,7 +501,7 @@ class QuizEqualityTests(QuizTestCase):
         """Test that quizzes are different if only the case of the question differs."""
         self.assertNotEqual(self.copy_quiz(self.quiz, question=str(self.quiz.question).upper()), self.quiz)
 
-    def test_equal_when_answers_have_different_case(self):
-        """Test that quizzes are equal if only the case of the answers differs."""
+    def test_not_equal_when_answers_have_different_case(self):
+        """Test that quizzes are not equal if only the case of the answers differs."""
         answers = [str(answer).lower() for answer in self.quiz.answers]
-        self.assertEqual(self.copy_quiz(self.quiz, answers=answers), self.quiz)
+        self.assertNotEqual(self.copy_quiz(self.quiz, answers=answers), self.quiz)

--- a/tests/toisto/persistence/test_progress.py
+++ b/tests/toisto/persistence/test_progress.py
@@ -9,7 +9,7 @@ from toisto.model.language import FI, Language
 from toisto.model.quiz.progress import Progress
 from toisto.model.quiz.quiz import Quizzes
 from toisto.model.quiz.retention import Retention
-from toisto.persistence.progress import load_progress, save_progress, update_progress_dict
+from toisto.persistence.progress import load_progress, save_progress, update_progress_dict, update_quiz_keys
 from toisto.persistence.progress_format import ProgressDict
 
 from ...base import ToistoTestCase
@@ -101,7 +101,8 @@ class UpdateProgressTest(ToistoTestCase):
     """Unit tests for the update progress method."""
 
     def setUp(self) -> None:
-        """Override to set up test fixtures."""
+        """Extend to set up test fixtures."""
+        super().setUp()
         self.grey: ProgressDict = {
             "grey:nl:fi:grijs:write": {
                 "start": "2023-03-06T22:29:25",
@@ -219,3 +220,60 @@ class UpdateProgressTest(ToistoTestCase):
         }
         update_progress_dict(self.friday_paused2, self.friday2)
         self.assertEqual(expected, self.friday_paused2)
+
+
+class UpdateQuizKeysTest(ToistoTestCase):
+    """Unit tests for the update quiz keys method."""
+
+    def setUp(self) -> None:
+        """Extend to set up test fixtures."""
+        super().setUp()
+        self.concept = self.create_concept("english", {})
+        self.quiz = self.create_quiz(self.concept, "englanti", ["Engels"])
+
+    def test_updating_an_empty_progress_dict_with_no_quizzes(self):
+        """Test that updating an empty progress without quizzes leaves the progress dict unchanged."""
+        empty: ProgressDict = {}
+        update_quiz_keys(empty, Quizzes())
+        self.assertEqual({}, empty)
+
+    def test_updating_an_empty_progress_dict_with_quizzes(self):
+        """Test that updating an empty progress with quizzes leaves the progress dict unchanged."""
+        empty: ProgressDict = {}
+        update_quiz_keys(empty, Quizzes([self.quiz]))
+        self.assertEqual({}, empty)
+
+    def test_updating_an_progress_dict_with_new_key(self):
+        """Test that updating a progress with the new key leaves the progress dict unchanged."""
+        progress_dict: ProgressDict = {
+            self.quiz.key: {
+                "start": "2023-03-06T22:29:47",
+                "end": "2023-12-03T13:53:57",
+                "skip_until": "2027-08-22T18:54:49",
+                "count": 5,
+            }
+        }
+        expected_progress_dict = progress_dict.copy()
+        update_quiz_keys(progress_dict, Quizzes([self.quiz]))
+        self.assertEqual(expected_progress_dict, progress_dict)
+
+    def test_updating_an_progress_dict_with_old_key(self):
+        """Test that updating a progress with the old key updates the key."""
+        progress_dict: ProgressDict = {
+            self.quiz.old_key: {
+                "start": "2023-03-06T22:29:47",
+                "end": "2023-12-03T13:53:57",
+                "skip_until": "2027-08-22T18:54:49",
+                "count": 5,
+            }
+        }
+        expected_progress_dict: ProgressDict = {
+            self.quiz.key: {
+                "start": "2023-03-06T22:29:47",
+                "end": "2023-12-03T13:53:57",
+                "skip_until": "2027-08-22T18:54:49",
+                "count": 5,
+            }
+        }
+        update_quiz_keys(progress_dict, Quizzes([self.quiz]))
+        self.assertEqual(expected_progress_dict, progress_dict)


### PR DESCRIPTION
Don't use concept id in quiz repr, but instead use question and answer so that progress doesn't get lost when the concept id changes.