### PR TITLE
Improve configure command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ## [Unreleased]
 
+### Fixed
+
+- Don't add an empty files section to the config file when the user has not configured any extra concept files to load. Fixes [#856](https://github.com/fniessink/toisto/issues/856).
+- Complain when an extra concept file does not exist. Fixes [#856](https://github.com/fniessink/toisto/issues/856).
+
 ### Changed
 
 - Use labels instead of concept identifiers when generating hints based on homonym relations between concepts.

--- a/src/toisto/command/configure.py
+++ b/src/toisto/command/configure.py
@@ -25,7 +25,7 @@ def configure(argument_parser: ArgumentParser, config: ConfigParser, args: Names
     if "mp3player" in args:
         ensure_section(config, "commands")
         config.set("commands", "mp3player", args.mp3player)
-    if "file" in args:
+    if "file" in args and args.file:
         ensure_section(config, "files")
         for file_path in args.file:
             config.set("files", str(file_path), "")

--- a/src/toisto/ui/cli.py
+++ b/src/toisto/ui/cli.py
@@ -34,6 +34,14 @@ def check_folder(folder: str) -> str:
     raise ArgumentTypeError(message)
 
 
+def check_file(path: str) -> Path:
+    """Check that the path is a file and exists."""
+    if Path(path).is_file():
+        return Path(path)
+    message = f"file '{path}' does not exist or is not a file"
+    raise ArgumentTypeError(message)
+
+
 class CommandBuilder:
     """Command builder."""
 
@@ -82,14 +90,16 @@ class CommandBuilder:
 
     def add_file_arguments(self, parser: ArgumentParser) -> None:
         """Add the file arguments."""
+        default = [Path(filename) for filename in self.config["files"]] if self.config.has_section("files") else []
+        default_help = ", ".join(str(path) for path in default) if default else "none"
         parser.add_argument(
             "-f",
             "--file",
             action="append",
-            default=[],
+            default=default,
             metavar="{file}",
-            help="file with extra concepts to read, can be repeated",
-            type=Path,
+            help=f"file with extra concepts to read, can be repeated; default: {default_help}",
+            type=check_file,
         )
 
     def add_progress_folder_argument(self, parser: ArgumentParser) -> None:

--- a/tests/toisto/test_app.py
+++ b/tests/toisto/test_app.py
@@ -51,7 +51,7 @@ class AppTest(ToistoTestCase):
         }}
         """
 
-    @patch.object(sys, "argv", ["toisto", "practice", "--target", "fi", "--source", "nl", "--file", "test"])
+    @patch.object(sys, "argv", ["toisto", "practice", "--target", "fi", "--source", "nl"])
     @patch("requests.get")
     def test_practice(self, requests_get: Mock) -> None:
         """Test that the practice command can be invoked."""
@@ -59,7 +59,7 @@ class AppTest(ToistoTestCase):
         patched_print = self.run_main()
         self.assertTrue(patched_print.call_args_list[2][0][0].startswith("👋 Welcome to [underline]Toisto"))
 
-    @patch.object(sys, "argv", ["toisto", "practice", "--target", "fi", "--source", "nl", "--file", "test"])
+    @patch.object(sys, "argv", ["toisto", "practice", "--target", "fi", "--source", "nl"])
     @patch("toisto.metadata.check_output", Mock(return_value="toisto"))
     @patch("requests.get")
     def test_new_version_when_current_version_was_installed_with_uv(self, requests_get: Mock) -> None:
@@ -69,7 +69,7 @@ class AppTest(ToistoTestCase):
         self.assertIn("v9999", patched_print.call_args_list[3][0][0].renderable)
         self.assertIn("uv tool upgrade", patched_print.call_args_list[3][0][0].renderable)
 
-    @patch.object(sys, "argv", ["toisto", "practice", "--target", "fi", "--source", "nl", "--file", "test"])
+    @patch.object(sys, "argv", ["toisto", "practice", "--target", "fi", "--source", "nl"])
     @patch("toisto.metadata.check_output", Mock(side_effect=["", "toisto"]))
     @patch("requests.get")
     def test_new_version_when_current_version_was_installed_with_pipx(self, requests_get: Mock) -> None:
@@ -79,7 +79,7 @@ class AppTest(ToistoTestCase):
         self.assertIn("v9999", patched_print.call_args_list[3][0][0].renderable)
         self.assertIn("pipx upgrade", patched_print.call_args_list[3][0][0].renderable)
 
-    @patch.object(sys, "argv", ["toisto", "practice", "--target", "fi", "--source", "nl", "--file", "test"])
+    @patch.object(sys, "argv", ["toisto", "practice", "--target", "fi", "--source", "nl"])
     @patch("toisto.metadata.check_output", Mock(side_effect=["", ""]))
     @patch("requests.get")
     def test_new_version_when_current_version_was_installed_with_pip(self, requests_get: Mock) -> None:
@@ -89,7 +89,7 @@ class AppTest(ToistoTestCase):
         self.assertIn("v9999", patched_print.call_args_list[3][0][0].renderable)
         self.assertIn("pip upgrade", patched_print.call_args_list[3][0][0].renderable)
 
-    @patch.object(sys, "argv", ["toisto", "practice", "--target", "fi", "--source", "nl", "--file", "test"])
+    @patch.object(sys, "argv", ["toisto", "practice", "--target", "fi", "--source", "nl"])
     @patch("toisto.metadata.check_output", Mock(side_effect=[OSError, "toisto"]))
     @patch("requests.get")
     def test_new_version_when_checking_for_installation_tool_fails(self, requests_get: Mock) -> None:
@@ -99,7 +99,7 @@ class AppTest(ToistoTestCase):
         self.assertIn("v9999", patched_print.call_args_list[3][0][0].renderable)
         self.assertIn("pipx upgrade", patched_print.call_args_list[3][0][0].renderable)
 
-    @patch.object(sys, "argv", ["toisto", "practice", "--target", "fi", "--source", "nl", "--file", "test"])
+    @patch.object(sys, "argv", ["toisto", "practice", "--target", "fi", "--source", "nl"])
     @patch("requests.get")
     def test_current_version(self, requests_get: Mock) -> None:
         """Test that the practice command does not show the current version."""
@@ -107,7 +107,7 @@ class AppTest(ToistoTestCase):
         patched_print = self.run_main()
         self.assertNotEqual(VERSION, patched_print.call_args_list[3][0][0].renderable)
 
-    @patch.object(sys, "argv", ["toisto", "practice", "--target", "fi", "--source", "nl", "--file", "test"])
+    @patch.object(sys, "argv", ["toisto", "practice", "--target", "fi", "--source", "nl"])
     @patch("requests.get")
     def test_github_connection_error(self, requests_get: Mock) -> None:
         """Test that the practice command starts even if GitHub cannot be reached to get the latest version."""
@@ -115,7 +115,7 @@ class AppTest(ToistoTestCase):
         patched_print = self.run_main()
         self.assertTrue(patched_print.call_args_list[2][0][0].startswith("👋 Welcome to [underline]Toisto"))
 
-    @patch.object(sys, "argv", ["toisto", "progress", "--target", "fi", "--source", "nl", "--file", "test"])
+    @patch.object(sys, "argv", ["toisto", "progress", "--target", "fi", "--source", "nl"])
     @patch("requests.get")
     def test_progress(self, requests_get: Mock) -> None:
         """Test that the progress command can be invoked."""


### PR DESCRIPTION
- Don't add an empty files section to the config file when the user has not configured any extra concept files to load.
- Complain when an extra concept file does not exist.

Fixes #856.