### PR TITLE
Expand file names before storing them in the config file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Toisto will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Expand file names before storing them in the config file. Fixes [#899](https://github.com/fniessink/toisto/issues/899).
+
 ## 0.28.0 - 2024-11-01
 
 ### Fixed

--- a/src/toisto/ui/cli.py
+++ b/src/toisto/ui/cli.py
@@ -37,7 +37,7 @@ def check_folder(folder: str) -> str:
 def check_file(path: str) -> Path:
     """Check that the path is a file and exists."""
     if Path(path).is_file():
-        return Path(path)
+        return Path(path).resolve()
     message = f"file '{path}' does not exist or is not a file"
     raise ArgumentTypeError(message)
 

--- a/tests/toisto/ui/test_cli.py
+++ b/tests/toisto/ui/test_cli.py
@@ -135,12 +135,30 @@ See {README_URL} for more information.
 
     @patch("sys.platform", "darwin")
     @patch("sys.argv", ["toisto", "configure", "--file", "/home/user/extra.json"])
+    @patch("toisto.ui.cli.Path.resolve", Mock(return_value=Path("/home/user/extra.json")))
     @patch("toisto.ui.cli.Path.is_file", Mock(return_value=True))
     def test_configure_concept_file(self) -> None:
         """Test that a concept file folder can be configured."""
         expected_namespace = Namespace(
             command="configure",
             file=[Path("/home/user/extra.json")],
+            mp3player="afplay",
+            progress_folder=str(home()),
+            progress_update=0,
+            source_language=None,
+            target_language=None,
+        )
+        self.assertEqual(expected_namespace, parse_arguments(self.argument_parser()))
+
+    @patch("sys.platform", "darwin")
+    @patch("sys.argv", ["toisto", "configure", "--file", "~/toisto/extra.json"])
+    @patch("toisto.ui.cli.Path.resolve", Mock(return_value=Path("/home/user/toisto/extra.json")))
+    @patch("toisto.ui.cli.Path.is_file", Mock(return_value=True))
+    def test_configure_concept_file_with_relative_path(self) -> None:
+        """Test that a concept file with a relative path can be configured."""
+        expected_namespace = Namespace(
+            command="configure",
+            file=[Path("/home/user/toisto/extra.json")],
             mp3player="afplay",
             progress_folder=str(home()),
             progress_update=0,


### PR DESCRIPTION
Fixes #899.