### PR TITLE
Fix antonym quizzes of concepts with multiple grammatical forms.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Toisto will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- When quizzing the antonym of one grammatical form of a concept with multiple grammatical forms, Toisto would accept all grammatical forms of the antonym concept. For example, when quizzing the antonym of halvempi in Finnish (cheaper), Toisto would accept kallis (expensive), kalliimpi (more expensive), and kallein (most expensive) as answer. Fixed to only accept the same grammatical form of the antonym concept, kalliimpi (more expensive) in the example. Fixes [#893](https://github.com/fniessink/toisto/issues/893).
+
 ## 0.29.0 - 2024-11-02
 
 ### Added

--- a/src/toisto/model/quiz/quiz_factory.py
+++ b/src/toisto/model/quiz/quiz_factory.py
@@ -195,7 +195,7 @@ class QuizFactory:
                 Labels(),
                 Labels(meanings),
             )
-            for label in concept.labels(target_language).non_colloquial
+            for label in concept.own_labels(target_language).non_colloquial
         )
 
     def order_quizzes(self, concept: Concept, previous_quizzes: Quizzes, min_word_count: int = 5) -> Quizzes:

--- a/tests/toisto/model/quiz/test_quiz_factory.py
+++ b/tests/toisto/model/quiz/test_quiz_factory.py
@@ -115,16 +115,16 @@ class QuizFactoryTestCase(ToistoTestCase):
             ),
         )
 
-    def create_adjective_with_degrees_of_comparison(self) -> Concept:
+    def create_adjective_with_degrees_of_comparison(self, antonym: str = "") -> Concept:
         """Create an adjective with degrees of comparison."""
-        return self.create_concept(
-            "big",
-            {
-                "positive degree": dict(en="big", nl="groot"),
-                "comparative degree": dict(en="bigger", nl="groter"),
-                "superlative degree": dict(en="biggest", nl="grootst"),
-            },
-        )
+        big: dict[str, object] = {
+            "positive degree": dict(en="big", nl="groot"),
+            "comparative degree": dict(en="bigger", nl="groter"),
+            "superlative degree": dict(en="biggest", nl="grootst"),
+        }
+        if antonym:
+            big["antonym"] = antonym
+        return self.create_concept("big", big)
 
     def create_noun(self) -> Concept:
         """Create a simple noun."""
@@ -538,6 +538,47 @@ class ConceptQuizzesTest(QuizFactoryTestCase):
                 self.create_quiz(concept, "suurin", ["suurempi"], COMPARATIVE_DEGREE),
             },
             create_quizzes(FI_EN, concept),
+        )
+
+    def test_degrees_of_comparison_with_antonym(self):
+        """Test that quizzes can be generated for degrees of comparison with antonym."""
+        self.language_pair = NL_EN
+        concept = self.create_adjective_with_degrees_of_comparison(antonym="small")
+        self.create_concept(
+            "small",
+            {
+                "antonym": "big",
+                "positive degree": dict(en="small", nl="klein"),
+                "comparative degree": dict(en="smaller", nl="kleiner"),
+                "superlative degree": dict(en="smallest", nl="kleinst"),
+            },
+        )
+        positive_degree, comparative_degree, superlative_degree = concept.leaf_concepts(NL)
+        self.assertSetEqual(
+            {
+                self.create_quiz(positive_degree, "groot", ["big"], READ),
+                self.create_quiz(positive_degree, "groot", ["groot"], DICTATE),
+                self.create_quiz(positive_degree, "groot", ["big"], INTERPRET),
+                self.create_quiz(positive_degree, "big", ["groot"], WRITE),
+                self.create_quiz(comparative_degree, "groter", ["bigger"], READ),
+                self.create_quiz(comparative_degree, "groter", ["groter"], DICTATE),
+                self.create_quiz(comparative_degree, "groter", ["bigger"], INTERPRET),
+                self.create_quiz(comparative_degree, "bigger", ["groter"], WRITE),
+                self.create_quiz(superlative_degree, "grootst", ["biggest"], READ),
+                self.create_quiz(superlative_degree, "grootst", ["grootst"], DICTATE),
+                self.create_quiz(superlative_degree, "grootst", ["biggest"], INTERPRET),
+                self.create_quiz(superlative_degree, "biggest", ["grootst"], WRITE),
+                self.create_quiz(concept, "groot", ["groter"], COMPARATIVE_DEGREE),
+                self.create_quiz(concept, "groot", ["grootst"], SUPERLATIVE_DEGREE),
+                self.create_quiz(concept, "groot", ["klein"], ANTONYM),
+                self.create_quiz(concept, "groter", ["groot"], POSITIVE_DEGREE),
+                self.create_quiz(concept, "groter", ["grootst"], SUPERLATIVE_DEGREE),
+                self.create_quiz(concept, "groter", ["kleiner"], ANTONYM),
+                self.create_quiz(concept, "grootst", ["groot"], POSITIVE_DEGREE),
+                self.create_quiz(concept, "grootst", ["groter"], COMPARATIVE_DEGREE),
+                self.create_quiz(concept, "grootst", ["kleinst"], ANTONYM),
+            },
+            create_quizzes(NL_EN, concept),
         )
 
     def test_grammatical_person(self):


### PR DESCRIPTION
When quizzing the antonym of one grammatical form of a concept with multiple grammatical forms, Toisto would accept all grammatical forms of the antonym concept. For example, when quizzing the antonym of halvempi in Finnish (cheaper), Toisto would accept kallis (expensive), kalliimpi (more expensive), and kallein (most expensive) as answer. Fixed to only accept the same grammatical form of the antonym concept, kalliimpi (more expensive) in the example.

Fixes #893.