### PR TITLE
Fix spelling of "linkerkant" and "rechterkant".

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Allow for selecting quiz types to use via the command-line interface. Closes [#318](https://github.com/fniessink/toisto/issues/318).
 - Add support for verbal nouns (fourth infinitive in Finnish).
 
+### Fixed
+
+- Fix spelling of "linkerkant" and "rechterkant". Fixes [#934](https://github.com/fniessink/toisto/issues/934).
+
 ## 0.33.2 - 2024-12-04
 
 ### Fixed

--- a/src/concepts/adpositions/to the left.json
+++ b/src/concepts/adpositions/to the left.json
@@ -4,7 +4,7 @@
         "example": "alice sits to the left of bob",
         "en": "to the left",
         "fi": "vasemmalla puolella",
-        "nl": "aan de linker kant"
+        "nl": "aan de linkerkant"
     },
     "alice sits to the left of bob": {
         "antonym": "alice sits to the right of bob",
@@ -14,6 +14,6 @@
         ],
         "en": "Alice sits to the left of Bob.",
         "fi": "Alice istuu Bobin vasemmalla puolella.",
-        "nl": "Alice zit aan de linker kant van Bob."
+        "nl": "Alice zit aan de linkerkant van Bob."
     }
 }

--- a/src/concepts/adpositions/to the right.json
+++ b/src/concepts/adpositions/to the right.json
@@ -4,7 +4,7 @@
         "example": "alice sits to the right of bob",
         "en": "to the right",
         "fi": "oikealla puolella",
-        "nl": "aan de rechter kant"
+        "nl": "aan de rechterkant"
     },
     "alice sits to the right of bob": {
         "antonym": "alice sits to the left of bob",
@@ -14,6 +14,6 @@
         ],
         "en": "Alice sits to the right of Bob.",
         "fi": "Alice istuu Bobin oikealla puolella.",
-        "nl": "Alice zit aan de rechter kant van Bob."
+        "nl": "Alice zit aan de rechterkant van Bob."
     }
 }


### PR DESCRIPTION
Fixes #934.