### PR TITLE
An erroneous import statement caused Toisto to crash when starting.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Toisto will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.34.1 - 2025-02-16
+
+### Fixed
+
+- An erroneous import statement caused Toisto to crash when starting. Fixes [#974](https://github.com/fniessink/toisto/issues/974).
+
 ## 0.34.0 - 2025-02-15
 
 ### Added

--- a/src/toisto/model/quiz/quiz_factory.py
+++ b/src/toisto/model/quiz/quiz_factory.py
@@ -3,9 +3,7 @@
 from abc import abstractmethod
 from dataclasses import dataclass
 from itertools import permutations, zip_longest
-from typing import ClassVar
-
-from green.output import Iterable
+from typing import ClassVar, Iterable
 
 from ..language import LanguagePair
 from ..language.concept import Concept, ConceptRelation


### PR DESCRIPTION
Fixes #974.