### PR TITLE
Fix startup problems

### DIFF
--- a/src/concepts/auxiliary_verbs.json
+++ b/src/concepts/auxiliary_verbs.json
@@ -176,12 +176,12 @@
                         "first person": "Me olemme maalaamassa taloa.",
                         "second person": "Te olette maalaamassa taloa.",
                         "third person": "He ovat maalaamassa taloa."
-                    },
-                    "roots": [
-                        "maalata",
-                        "talo"
-                    ]
-                }
+                    }
+                },
+                "roots": [
+                    "maalata",
+                    "talo"
+                ]
             },
             {
                 "concept": "to be able to",
@@ -195,12 +195,12 @@
                         "first person": "Me osaamme maalata talon.",
                         "second person": "Te osaatte maalata talon.",
                         "third person": "He osaavat maalata talon."
-                    },
-                    "roots": [
-                        "maalata",
-                        "talo"
-                    ]
-                }
+                    }
+                },
+                "roots": [
+                    "maalata",
+                    "talo"
+                ]
             },
             {
                 "concept": "to have to",
@@ -214,12 +214,12 @@
                         "first person": "Meidän täytyy maalata talo.",
                         "second person": "Teidän täytyy maalata talo.",
                         "third person": "Heidän täytyy maalata talo."
-                    },
-                    "roots": [
-                        "maalata",
-                        "talo"
-                    ]
-                }
+                    }
+                },
+                "roots": [
+                    "maalata",
+                    "talo"
+                ]
             },
             {
                 "concept": "to be allowed to",
@@ -233,12 +233,12 @@
                         "first person": "Me saamme maalata talon.",
                         "second person": "Te saatte maalata talon.",
                         "third person": "He saavat maalata talon."
-                    },
-                    "roots": [
-                        "maalata",
-                        "talo"
-                    ]
-                }
+                    }
+                },
+                "roots": [
+                    "maalata",
+                    "talo"
+                ]
             },
             {
                 "concept": "to want to",
@@ -252,13 +252,13 @@
                         "first person": "Me haluamme maalata talon.",
                         "second person": "Te haluatte maalata talon.",
                         "third person": "He haluavat maalata talon."
-                    },
-                    "roots": [
-                        "haluta",
-                        "maalata",
-                        "talo"
-                    ]
-                }
+                    }
+                },
+                "roots": [
+                    "haluta",
+                    "maalata",
+                    "talo"
+                ]
             }
         ],
         "nl": [
@@ -277,12 +277,12 @@
                         "first person": "Wij hebben het huis geschilderd.",
                         "second person": "Jullie hebben het huis geschilderd.",
                         "third person": "Zij hebben het huis geschilderd."
-                    },
-                    "roots": [
-                        "schilderen",
-                        "het huis"
-                    ]
-                }
+                    }
+                },
+                "roots": [
+                    "schilderen",
+                    "het huis"
+                ]
             },
             {
                 "concept": "to be (aux)",
@@ -299,13 +299,13 @@
                         "first person": "Wij zijn het huis aan het schilderen.",
                         "second person": "Jullie zijn het huis aan het schilderen.",
                         "third person": "Zij zijn het huis aan het schilderen."
-                    },
-                    "roots": [
-                        "zijn",
-                        "schilderen",
-                        "het huis"
-                    ]
-                }
+                    }
+                },
+                "roots": [
+                    "zijn",
+                    "schilderen",
+                    "het huis"
+                ]
             },
             {
                 "concept": "to be able to",
@@ -322,13 +322,13 @@
                         "first person": "Wij kunnen het huis schilderen.",
                         "second person": "Jullie kunnen het huis schilderen.",
                         "third person": "Zij kunnen het huis schilderen."
-                    },
-                    "roots": [
-                        "kunnen",
-                        "schilderen",
-                        "het huis"
-                    ]
-                }
+                    }
+                },
+                "roots": [
+                    "kunnen",
+                    "schilderen",
+                    "het huis"
+                ]
             },
             {
                 "concept": "to have to",
@@ -345,12 +345,12 @@
                         "first person": "Wij moeten het huis schilderen.",
                         "second person": "Jullie moeten het huis schilderen.",
                         "third person": "Zij moeten het huis schilderen."
-                    },
-                    "roots": [
-                        "schilderen",
-                        "het huis"
-                    ]
-                }
+                    }
+                },
+                "roots": [
+                    "schilderen",
+                    "het huis"
+                ]
             },
             {
                 "concept": "to be allowed to",
@@ -367,12 +367,12 @@
                         "first person": "Wij mogen het huis schilderen.",
                         "second person": "Jullie mogen het huis schilderen.",
                         "third person": "Zij mogen het huis schilderen."
-                    },
-                    "roots": [
-                        "schilderen",
-                        "het huis"
-                    ]
-                }
+                    }
+                },
+                "roots": [
+                    "schilderen",
+                    "het huis"
+                ]
             },
             {
                 "concept": "to want to",
@@ -389,13 +389,13 @@
                         "first person": "Wij willen het huis schilderen.",
                         "second person": "Jullie willen het huis schilderen.",
                         "third person": "Zij willen het huis schilderen."
-                    },
-                    "roots": [
-                        "willen",
-                        "schilderen",
-                        "het huis"
-                    ]
-                }
+                    }
+                },
+                "roots": [
+                    "willen",
+                    "schilderen",
+                    "het huis"
+                ]
             }
         ]
     }

--- a/src/concepts/nouns/game.json
+++ b/src/concepts/nouns/game.json
@@ -81,12 +81,12 @@
                     "plural": [
                         "de bordspellen",
                         "de bordspelen"
-                    ],
-                    "roots": [
-                        "het bord",
-                        "het spel"
                     ]
-                }
+                },
+                "roots": [
+                    "het bord",
+                    "het spel"
+                ]
             },
             {
                 "concept": "computer game",

--- a/src/toisto/model/language/label.py
+++ b/src/toisto/model/language/label.py
@@ -184,6 +184,19 @@ class Label:
         """Return the label compounds."""
         return Labels(label for label in chain(*self.homograph_mapping.values()) if self in label.roots)
 
+    @property
+    def is_grammatical_base(self) -> bool:
+        """Return whether this label has the grammatical base form."""
+        return str(self) == self.grammatical_base
+
+    def has_same_grammatical_form(self, other: Label) -> bool:
+        """Return whether this label has the same grammatical form as the other label."""
+        return (
+            self.grammatical_categories == other.grammatical_categories
+            or (not self.grammatical_categories and other.is_grammatical_base)
+            or (not other.grammatical_categories and self.is_grammatical_base)
+        )
+
     def grammatical_differences(self, *labels: Label) -> tuple[GrammaticalCategory, ...]:
         """Return the grammatical differences between this label and the other labels."""
         differences = set()
@@ -247,7 +260,7 @@ class Labels:  # noqa: PLW1641
 
     def with_same_grammatical_categories_as(self, other: Label) -> Labels:
         """Return the labels with the specified grammatical categories."""
-        return Labels(label for label in self._labels if label.grammatical_categories == other.grammatical_categories)
+        return Labels(label for label in self._labels if label.has_same_grammatical_form(other))
 
     @property
     def non_colloquial(self) -> Labels:

--- a/src/toisto/model/quiz/quiz_factory.py
+++ b/src/toisto/model/quiz/quiz_factory.py
@@ -55,7 +55,7 @@ class BaseQuizFactory:
                 answer_meanings,
             )
             for question, answer in self.zip_questions_and_answers(questions, answers)
-            if self.include_question(question, answer)
+            if self.include_question(question, answer) and self.answers_for_question(question, answer, answers)
         )
 
     def skip_quiz_type(self) -> bool:


### PR DESCRIPTION
- Some labels had roots as part of the label key.
- Semantic quizzes would fail if the grammar of the related concepts was different.