### PR TITLE
Grammatical number pronoun

### DIFF
--- a/docs/software.md
+++ b/docs/software.md
@@ -717,9 +717,11 @@ In the JSON file this looks as follows:
 
 ### Grammatical number
 
-When concepts can have both singular and plural forms, such as with most nouns, these are represented in the JSON as mappings with `singular` and `plural` as keys and labels as values.
+Most verbs, nouns, and pronouns can occur in both singular and plural forms. These forms are represented in the JSON as mapping with a key for the singular form and a key for the plural form. The values can be be strings or list of strings (in case of spelling alternatives) or other grammatical forms.
 
-The format of the JSON files is as follows:
+#### Nouns
+
+Nouns are represented as follows:
 
 ```json
 {
@@ -742,6 +744,69 @@ The format of the JSON files is as follows:
                 "label": {
                     "singular": "päivä",
                     "plural": "päivät"
+                }
+            }
+        ]
+    }
+}
+```
+
+#### Verbs
+
+Verbs are represented as follows:
+
+```json
+{
+    "concepts": {
+        "to have"
+    },
+    "labels": {
+        "en": [
+            {
+                "concept": "to have",
+                "label": {
+                    "singular": {
+                        "first person": "I have",
+                        "second person": "you have",
+                        "third person": {
+                            "feminine": "she has",
+                            "masculine": "he has"
+                        }
+                    },
+                    "plural": {
+                        "first person": "we have",
+                        "second person": "you have",
+                        "third person": "they have"
+                    }
+                }
+            }
+        ]
+    }
+}
+```
+
+#### Pronouns
+
+As the grammatical number of pronouns doesn't necessarily agree with the grammatical person of the noun, pronouns have their own keys `singular pronoun` and `plural pronoun`:
+
+```json
+{
+    "concepts": {
+        "cat": {}
+    },
+    "labels": {
+        "en": [
+            {
+                "concept": "cat",
+                "label": {
+                    "singular": {
+                        "singular pronoun": "my cat",
+                        "plural pronoun": "our cat",
+                    },
+                    "plural": {
+                        "singular pronoun": "my cats",
+                        "plural pronoun": "our cats",
+                    }
                 }
             }
         ]

--- a/src/concepts/possessive_adjectives.json
+++ b/src/concepts/possessive_adjectives.json
@@ -9,22 +9,22 @@
                 "concept": "possessive pronoun cat",
                 "label": {
                     "singular": {
-                        "singular": {
+                        "singular pronoun": {
                             "first person": "my cat",
                             "second person": "your cat",
                             "third person": {
                                 "feminine": "her cat",
-                                "masculine": "his cats"
+                                "masculine": "his cat"
                             }
                         },
-                        "plural": {
+                        "plural pronoun": {
                             "first person": "our cat",
                             "second person": "your cat",
                             "third person": "their cat"
                         }
                     },
                     "plural": {
-                        "singular": {
+                        "singular pronoun": {
                             "first person": "my cats",
                             "second person": "your cats",
                             "third person": {
@@ -32,7 +32,7 @@
                                 "masculine": "his cats"
                             }
                         },
-                        "plural": {
+                        "plural pronoun": {
                             "first person": "our cats",
                             "second person": "your cats",
                             "third person": "their cats"
@@ -45,7 +45,7 @@
                 "concept": "possessive pronoun house",
                 "label": {
                     "singular": {
-                        "singular": {
+                        "singular pronoun": {
                             "first person": "my house",
                             "second person": "your house",
                             "third person": {
@@ -53,14 +53,14 @@
                                 "masculine": "his house"
                             }
                         },
-                        "plural": {
+                        "plural pronoun": {
                             "first person": "our house",
                             "second person": "your house",
                             "third person": "their house"
                         }
                     },
                     "plural": {
-                        "singular": {
+                        "singular pronoun": {
                             "first person": "my houses",
                             "second person": "your houses",
                             "third person": {
@@ -68,7 +68,7 @@
                                 "masculine": "his houses"
                             }
                         },
-                        "plural": {
+                        "plural pronoun": {
                             "first person": "our houses",
                             "second person": "your houses",
                             "third person": "their houses"
@@ -83,24 +83,24 @@
                 "concept": "possessive pronoun cat",
                 "label": {
                     "singular": {
-                        "singular": {
+                        "singular pronoun": {
                             "first person": "minun kissani",
                             "second person": "sinun kissasi",
                             "third person": "hänen kissansa"
                         },
-                        "plural": {
+                        "plural pronoun": {
                             "first person": "meidän kissamme",
                             "second person": "teidän kissanne",
                             "third person": "heidän kissansa"
                         }
                     },
                     "plural": {
-                        "singular": {
+                        "singular pronoun": {
                             "first person": "minun kissani",
                             "second person": "sinun kissasi",
                             "third person": "hänen kissansa"
                         },
-                        "plural": {
+                        "plural pronoun": {
                             "first person": "meidän kissamme",
                             "second person": "teidän kissanne",
                             "third person": "heidän kissansa"
@@ -113,24 +113,24 @@
                 "concept": "possessive pronoun house",
                 "label": {
                     "singular": {
-                        "singular": {
+                        "singular pronoun": {
                             "first person": "minun taloni",
                             "second person": "sinun talosi",
                             "third person": "hänen talonsa"
                         },
-                        "plural": {
+                        "plural pronoun": {
                             "first person": "meidän talomme",
                             "second person": "teidän talonne",
                             "third person": "heidän talonsa"
                         }
                     },
                     "plural": {
-                        "singular": {
+                        "singular pronoun": {
                             "first person": "minun taloni",
                             "second person": "sinun talosi",
                             "third person": "hänen talonsa"
                         },
-                        "plural": {
+                        "plural pronoun": {
                             "first person": "meidän talomme",
                             "second person": "teidän talonne",
                             "third person": "heidän talonsa"
@@ -145,22 +145,22 @@
                 "concept": "possessive pronoun cat",
                 "label": {
                     "singular": {
-                        "singular": {
+                        "singular pronoun": {
                             "first person": "mijn kat",
                             "second person": "jouw kat",
                             "third person": {
                                 "feminine": "haar kat",
-                                "masculine": "zijn katten"
+                                "masculine": "zijn kat"
                             }
                         },
-                        "plural": {
+                        "plural pronoun": {
                             "first person": "onze kat",
                             "second person": "jullie kat",
                             "third person": "hun kat"
                         }
                     },
                     "plural": {
-                        "singular": {
+                        "singular pronoun": {
                             "first person": "mijn katten",
                             "second person": "jouw katten",
                             "third person": {
@@ -168,7 +168,7 @@
                                 "masculine": "zijn katten"
                             }
                         },
-                        "plural": {
+                        "plural pronoun": {
                             "first person": "onze katten",
                             "second person": "jullie katten",
                             "third person": "hun katten"
@@ -181,7 +181,7 @@
                 "concept": "possessive pronoun house",
                 "label": {
                     "singular": {
-                        "singular": {
+                        "singular pronoun": {
                             "first person": "mijn huis",
                             "second person": "jouw huis",
                             "third person": {
@@ -189,14 +189,14 @@
                                 "masculine": "zijn huis"
                             }
                         },
-                        "plural": {
+                        "plural pronoun": {
                             "first person": "ons huis",
                             "second person": "jullie huis",
                             "third person": "hun huis"
                         }
                     },
                     "plural": {
-                        "singular": {
+                        "singular pronoun": {
                             "first person": "mijn huizen",
                             "second person": "jouw huizen",
                             "third person": {
@@ -204,7 +204,7 @@
                                 "masculine": "zijn huizen"
                             }
                         },
-                        "plural": {
+                        "plural pronoun": {
                             "first person": "onze huizen",
                             "second person": "jullie huizen",
                             "third person": "hun huizen"

--- a/src/toisto/model/language/grammatical_category.py
+++ b/src/toisto/model/language/grammatical_category.py
@@ -6,6 +6,7 @@ from typing import Literal
 
 GrammaticalGender = Literal["feminine", "masculine", "neuter"]
 GrammaticalNumber = Literal["infinitive", "verbal noun", "singular", "plural"]
+GrammaticalNumberPronoun = Literal["singular pronoun", "plural pronoun"]
 GrammaticalPerson = Literal["first person", "second person", "third person"]
 DegreeOfComparison = Literal["positive degree", "comparative degree", "superlative degree"]
 Diminutive = Literal["root", "diminutive"]
@@ -17,6 +18,7 @@ Abbreviation = Literal["abbreviation", "full form"]
 GrammaticalCategory = Literal[
     GrammaticalGender,
     GrammaticalNumber,
+    GrammaticalNumberPronoun,
     GrammaticalPerson,
     DegreeOfComparison,
     Diminutive,

--- a/src/toisto/model/quiz/quiz_type.py
+++ b/src/toisto/model/quiz/quiz_type.py
@@ -198,6 +198,8 @@ INTERPRET = ListenOnlyQuizType("interpret")
 # Grammatical quiz types
 PLURAL = GrammaticalQuizType("plural")
 SINGULAR = GrammaticalQuizType("singular")
+PLURAL_PRONOUN = GrammaticalQuizType("plural pronoun")
+SINGULAR_PRONOUN = GrammaticalQuizType("singular pronoun")
 FIRST_PERSON = GrammaticalQuizType("first person")
 SECOND_PERSON = GrammaticalQuizType("second person")
 THIRD_PERSON = GrammaticalQuizType("third person")

--- a/tests/toisto/model/language/test_label_factory.py
+++ b/tests/toisto/model/language/test_label_factory.py
@@ -59,6 +59,21 @@ class LabelFactoryTestCase(ToistoTestCase):
         }
         return self.with_tip_or_note(label_json, tip, note)
 
+    def label_with_nested_grammatical_number(self, *, tip: JSONGrammar = "", note: JSONGrammar = "") -> LabelJSON:
+        """Create a label with nested grammatical number."""
+        label_json: LabelJSON = {
+            "concept": ConceptId("chair"),
+            "label": cast(
+                "JSONGrammar",
+                {
+                    "singular": {"singular pronoun": "my chair", "plural pronoun": "our chair"},
+                    "plural": {"singular pronoun": "my chairs", "plural pronoun": "our chairs"},
+                },
+            ),
+            "language": EN,
+        }
+        return self.with_tip_or_note(label_json, tip, note)
+
 
 class LabelFactoryTest(LabelFactoryTestCase):
     """Label factory unit tests."""
@@ -110,6 +125,20 @@ class LabelFactoryTest(LabelFactoryTestCase):
                 Label(NL, "de stoelen", GrammaticalForm(base, "root", "plural")),
                 Label(NL, "het stoeltje", GrammaticalForm(base, "diminutive", "singular")),
                 Label(NL, "de stoeltjes", GrammaticalForm(base, "diminutive", "plural")),
+            ),
+            self.factory.create_labels([chair_json]),
+        )
+
+    def test_create_label_with_nested_grammatical_number(self):
+        """Test creating labels with nested grammatical number."""
+        chair_json = self.label_with_nested_grammatical_number()
+        base = "my chair"
+        self.assertEqual(
+            (
+                Label(EN, "my chair", GrammaticalForm(base, "singular", "singular pronoun")),
+                Label(EN, "our chair", GrammaticalForm(base, "singular", "plural pronoun")),
+                Label(EN, "my chairs", GrammaticalForm(base, "plural", "singular pronoun")),
+                Label(EN, "our chairs", GrammaticalForm(base, "plural", "plural pronoun")),
             ),
             self.factory.create_labels([chair_json]),
         )

--- a/tests/toisto/model/quiz/quiz_factory/test_grammatical_number.py
+++ b/tests/toisto/model/quiz/quiz_factory/test_grammatical_number.py
@@ -11,9 +11,11 @@ from toisto.model.quiz.quiz_type import (
     INTERPRET,
     MASCULINE,
     PLURAL,
+    PLURAL_PRONOUN,
     READ,
     SECOND_PERSON,
     SINGULAR,
+    SINGULAR_PRONOUN,
     THIRD_PERSON,
     WRITE,
 )
@@ -44,6 +46,23 @@ class GrammaticalNumberQuizzesTest(QuizFactoryTestCase):
                 self.create_quiz(concept, aamut, [aamu], SINGULAR),
             },
             create_quizzes(FI_NL, (), concept),
+        )
+
+    def test_grammatical_number_pronoun(self):
+        """Test that quizzes can be generated for different grammatical numbers of pronouns."""
+        concept = self.create_concept(
+            "cat",
+            labels=[{"label": {"singular pronoun": "my cat", "plural pronoun": "our cat"}, "language": EN}],
+        )
+        my_cat, our_cat = concept.labels(EN)
+        self.assertSetEqual(
+            {
+                self.create_quiz(concept, my_cat, [our_cat], PLURAL_PRONOUN),
+                self.create_quiz(concept, our_cat, [my_cat], SINGULAR_PRONOUN),
+                self.create_quiz(concept, my_cat, [my_cat], DICTATE),
+                self.create_quiz(concept, our_cat, [our_cat], DICTATE),
+            },
+            create_quizzes(EN_NL, (), concept),
         )
 
     def test_grammatical_number_without_plural(self):

--- a/tests/toisto/ui/test_cli.py
+++ b/tests/toisto/ui/test_cli.py
@@ -48,9 +48,9 @@ QUIZ_TYPE_OPTION = """-q, --quiz-type {quiz type}
                         quiz types to use, can be repeated; default: all; available quiz types: abbreviation,
                         affirmative, answer, antonym, cardinal, comparative degree, declarative, dictate, diminutive,
                         feminine, first person, full form, imperative, infinitive, interpret, interrogative,
-                        masculine, negative, neuter, order, ordinal, past perfect tense, past tense, plural, positive
-                        degree, present perfect tense, present tense, read, second person, singular, superlative
-                        degree, third person, verbal noun, write"""
+                        masculine, negative, neuter, order, ordinal, past perfect tense, past tense, plural, plural
+                        pronoun, positive degree, present perfect tense, present tense, read, second person, singular,
+                        singular pronoun, superlative degree, third person, verbal noun, write"""
 HELP_MESSAGE = f"""Usage: toisto [-h] [-V] {{configure,practice,progress,self}} ...
 
 Toisto is a command-line terminal app to practice languages.


### PR DESCRIPTION
As the grammatical number of pronouns does not necessarily agree with the grammatical number of its noun, add separate keys for the grammatical number of pronouns: `singular pronoun` and `plural pronoun`.