### PR TITLE
Add notes for full form and abbreviations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 - Only show the base grammatical form of labels when listing the concepts users can practice under `toisto practice --help`. Fixes [#1072](https://github.com/fniessink/toisto/issues/1072).
 - Give the correct meaning when the quiz is an interpret quiz with singular and plural forms. Fixes [#1090](https://github.com/fniessink/toisto/issues/1090).
-- Apply the tip for the Finnish verb 'to have',  which is 'olla', to the infinitive only. Fixes [#1091](https://github.com/fniessink/toisto/issues/1091).
+- Apply the tip for the Finnish verb 'to have', which is 'olla', to the infinitive only. Fixes [#1091](https://github.com/fniessink/toisto/issues/1091).
 
 ### Added
 
+- Show one random alternative grammatical form of the question after non-grammatical quizzes. Closes [#970](https://github.com/fniessink/toisto/issues/970).
 - Add command to upgrade Toisto to the latest version (`toisto self upgrade`). Closes [#1045](https://github.com/fniessink/toisto/issues/1045).
 - Add command to uninstall Toisto (`toisto self uninstall`). Closes [#1046](https://github.com/fniessink/toisto/issues/1046).
 - Add option to show quiz retention after each quiz (`toisto --show-quiz-retention yes`, to configure: `toisto configure --show-quiz-retention yes`).

--- a/src/toisto/model/language/grammatical_form.py
+++ b/src/toisto/model/language/grammatical_form.py
@@ -10,7 +10,7 @@ class GrammaticalForm:
 
     def __init__(self, grammatical_base: str = "", /, *grammatical_categories: GrammaticalCategory) -> None:
         self.grammatical_base = grammatical_base  # Base form of a label, for example "table" is the base of "tables"
-        self.grammatical_categories = set(grammatical_categories)
+        self.grammatical_categories = frozenset(grammatical_categories)
 
     def __eq__(self, other: object) -> bool:
         """Return whether the grammatical forms are equal."""
@@ -34,6 +34,6 @@ class GrammaticalForm:
         """Return the hash."""
         return hash(f"{self.grammatical_base}{sorted(str(category) for category in self.grammatical_categories)}")
 
-    def grammatical_differences(self, other: GrammaticalForm) -> set[GrammaticalCategory]:
+    def grammatical_differences(self, other: GrammaticalForm) -> frozenset[GrammaticalCategory]:
         """Return the grammatical differences between this grammatical form and the other form."""
         return other.grammatical_categories.difference(self.grammatical_categories)

--- a/src/toisto/model/quiz/quiz.py
+++ b/src/toisto/model/quiz/quiz.py
@@ -139,7 +139,7 @@ class Quiz:
     def _homonym_tips(self, *homonym_labels: Label) -> Sequence[str]:
         """Return the tip(s) to be shown as part of the question, if the question has one or more homonyms."""
         if differences := self._question.grammatical_differences(*homonym_labels):
-            return [str(category) for category in differences]
+            return [str(category) for category in sorted(differences)]
         language = self.question.language
         if hypernyms := self.concept.get_related_concepts("hypernym"):
             return [str(hypernym.labels(language)[0]) for hypernym in hypernyms[:1]]

--- a/src/toisto/model/quiz/quiz_type.py
+++ b/src/toisto/model/quiz/quiz_type.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import random
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from itertools import chain
@@ -55,7 +56,17 @@ class QuizType:
 
         Subclasses may use the answers to generate the notes.
         """
-        return question.notes
+        notes = list(question.notes)
+        if self._include_grammatical_notes() and question.other_grammatical_categories:
+            other_grammatical_category = random.choice(list(question.other_grammatical_categories.keys()))  # noqa: S311 # nosec
+            other_label = question.other_grammatical_categories[other_grammatical_category]
+            also = " also" if str(question) == str(other_label) else ""
+            notes.append(f"The {other_grammatical_category} of '{question}' is{also} '{other_label}'.")
+        return tuple(notes)
+
+    def _include_grammatical_notes(self) -> bool:
+        """Return whether to include the grammatical notes for the grammatical categories."""
+        return True
 
     def other_answers(self, guess: Label, answers: Labels) -> Labels:
         """Return the answers not equal to the guess."""
@@ -139,6 +150,10 @@ class GrammaticalQuizType(QuizType):
     def _composite_action(self, *, separator: str) -> str:
         """Return the composite action."""
         return separator.join(sorted(quiz_type.action for quiz_type in self.quiz_types))
+
+    def _include_grammatical_notes(self) -> bool:
+        """Return whether to include the grammatical notes for the grammatical categories."""
+        return False
 
 
 @final


### PR DESCRIPTION
After a quiz for a full form or abbreviations, show the abbreviation or full form respectively.

Closes #970.