### PR TITLE
Don't give meaning of grammatical form not quizzed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 
 - Labels in notes did not get a link to Wiktionary. Fixes [#1113](https://github.com/fniessink/toisto/issues/1113).
+- After a dictate quiz, don't give the meaning of the singular form when the plural form was quizzed. Fixes [#1120](https://github.com/fniessink/toisto/issues/1120).
 
 ## 0.37.0 - 2025-09-09
 

--- a/src/toisto/model/quiz/quiz_factory.py
+++ b/src/toisto/model/quiz/quiz_factory.py
@@ -160,7 +160,7 @@ class WriteQuizFactory(TranslationQuizFactory):
 
 @dataclass
 class DictateQuizFactory(TranslationQuizFactory):
-    """Create dicate quizzes for a concept."""
+    """Create dictate quizzes for a concept."""
 
     quiz_type: QuizType | None = DICTATE
 
@@ -174,7 +174,7 @@ class DictateQuizFactory(TranslationQuizFactory):
 
     def question_meanings(self, question: Label, concept: Concept) -> Labels:
         """Return the question meanings of the concept."""
-        return concept.meanings(self.language_pair.source)
+        return concept.meanings(self.language_pair.source).with_same_grammatical_categories_as(question)
 
     def answers_for_question(self, question: Label, answer: Label, answers: Labels) -> Labels:
         """Return the answers for the question."""

--- a/tests/toisto/model/quiz/quiz_factory/test_meaning.py
+++ b/tests/toisto/model/quiz/quiz_factory/test_meaning.py
@@ -3,9 +3,9 @@
 from toisto.model.language import EN, FI, NL
 from toisto.model.language.label import Label
 from toisto.model.quiz.quiz_factory import create_quizzes
-from toisto.model.quiz.quiz_type import INTERPRET
+from toisto.model.quiz.quiz_type import DICTATE, INTERPRET
 
-from .....base import FI_EN, FI_NL, ToistoTestCase
+from .....base import EN_NL, FI_EN, FI_NL, ToistoTestCase
 
 
 class MeaningsTest(ToistoTestCase):
@@ -40,3 +40,19 @@ class MeaningsTest(ToistoTestCase):
         for quiz in interpret_quizzes:
             self.assertEqual((Label(FI, "kaksikymmentä"),), quiz.question_meanings)
             self.assertEqual((), quiz.answer_meanings)
+
+    def test_dictate_with_plural(self):
+        """Test that the meaning of a quiz that dictates a singular does not include plural."""
+        concept = self.create_concept(
+            "table",
+            labels=[
+                {"label": {"singular": "table", "plural": "tables"}, "language": EN},
+                {"label": {"singular": "de tafel", "plural": "de tafels"}, "language": NL},
+            ],
+        )
+        dictate_quizzes = create_quizzes(EN_NL, (DICTATE,), concept)
+        for quiz in dictate_quizzes:
+            self.assertEqual(
+                ("de tafel",) if str(quiz.question) == "table" else ("de tafels",),
+                tuple(str(meaning) for meaning in quiz.question_meanings),
+            )


### PR DESCRIPTION
After a dictate quiz, don't give the meaning of the singular form when the plural form was quizzed.

Fixes #1120.