### PR TITLE
Don't repeat notes for a repeated incorrect answer

### DIFF
--- a/src/toisto/model/language/translation.py
+++ b/src/toisto/model/language/translation.py
@@ -1,0 +1,18 @@
+"""Translating labels."""
+
+from . import Language
+from .concept import Concept
+from .label import Label, Labels
+
+
+def meanings(source_label: Label, target_language: Language) -> Labels:
+    """Return the meanings of the source label in the target language."""
+    source_language = source_label.language
+    return Labels(
+        [
+            meaning
+            for concept in Concept.instances.get_all_values()
+            for label in concept.labels(source_language).matching(source_label)
+            for meaning in concept.meanings(target_language).with_same_grammatical_categories_as(label)
+        ]
+    )

--- a/src/toisto/tools.py
+++ b/src/toisto/tools.py
@@ -2,7 +2,7 @@
 
 import os
 import sys
-from collections.abc import Callable, Iterable
+from collections.abc import Callable, Generator, Iterable
 from itertools import chain
 from typing import Generic, TypeVar
 
@@ -23,6 +23,15 @@ def first(sequence: Iterable[T], where: Callable[[T], bool] = lambda _item: True
 def first_upper(string: str) -> str:
     """Return a copy of the string with the first letter capitalized and the rest unchanged."""
     return string[0].upper() + string[1:] if string else ""
+
+
+def unique(sequence: Iterable[T]) -> Generator[T, None, None]:
+    """Return a generator that yields unique items from the sequence in order."""
+    seen = set()
+    for item in sequence:
+        if item not in seen:
+            seen.add(item)
+            yield item
 
 
 Key = TypeVar("Key")

--- a/tests/toisto/test_tools.py
+++ b/tests/toisto/test_tools.py
@@ -2,7 +2,7 @@
 
 import unittest
 
-from toisto.tools import first, first_upper
+from toisto.tools import first, first_upper, unique
 
 
 class FirstTest(unittest.TestCase):
@@ -37,3 +37,27 @@ class FirstUpperTest(unittest.TestCase):
         """Test non-empty strings."""
         self.assertEqual("Unchanged", first_upper("Unchanged"))
         self.assertEqual("Upper case, Upper case", first_upper("upper case, Upper case"))
+
+
+class UniqueTest(unittest.TestCase):
+    """Unit tests for the unique function."""
+
+    def test_empty_sequence(self):
+        """Test the empty sequence."""
+        self.assertEqual([], list(unique([])))
+
+    def test_one_element(self):
+        """Test a sequence with one element."""
+        self.assertEqual([1], list(unique([1])))
+
+    def test_two_elements(self):
+        """Test a sequence with two elements."""
+        self.assertEqual([1, 2], list(unique([1, 2])))
+
+    def test_two_equal_elements(self):
+        """Test a sequence with two equal elements."""
+        self.assertEqual([2], list(unique([2, 2])))
+
+    def test_mix_of_elements(self):
+        """Test a sequence with a mix of equal and unequal elements."""
+        self.assertEqual([1, 2, 4, 3], list(unique([1, 2, 2, 4, 2, 3, 1])))

--- a/tests/toisto/ui/test_text.py
+++ b/tests/toisto/ui/test_text.py
@@ -263,6 +263,25 @@ class FeedbackNotesTest(ToistoTestCase):
             feedback.text(Evaluation.CORRECT, Label(NL, "hoi"), Retention()),
         )
 
+    def test_note_on_incorrect_answer_that_has_different_meaning_that_is_repeated(self):
+        """Test that the note is not repeated if the same incorrect answer is given twice."""
+        self.create_concept(
+            "hello",
+            labels=[{"label": "terve", "language": FI}, {"label": "hallo", "language": NL}],
+        )
+        hi = self.create_concept(
+            "hi",
+            labels=[{"label": "moi", "language": FI}, {"label": "hoi", "language": NL}],
+        )
+        quiz = create_quizzes(FI_NL, (INTERPRET,), hi).pop()
+        feedback = Feedback(quiz, FI_NL)
+        feedback.incorrect_guesses = [Label(NL, "hallo")]
+        self.assertIn(
+            f"[secondary]Note: Your incorrect answer '{linkified('hallo')}' is "
+            f"'{linkified('terve')}' in Finnish.[/secondary]",
+            feedback.text(Evaluation.INCORRECT, Label(NL, "hallo"), Retention()),
+        )
+
     def test_note_on_incorrect_answer_that_has_different_meaning_and_is_spelling_variant(self):
         """Test that the note is given when the answer is incorrect."""
         self.create_concept(


### PR DESCRIPTION
If the user gives the same incorrect answer twice, and the guess has a meaning, don't repeat the note giving the meaning of the incorrect answer.