### PR TITLE
Split secondary style into multiple styles

### DIFF
--- a/src/toisto/model/quiz/quiz_type.py
+++ b/src/toisto/model/quiz/quiz_type.py
@@ -59,12 +59,12 @@ class QuizType:
         """
         notes = list(question.notes)
         if self._include_grammatical_notes() and question.other_grammatical_categories:
-            other_grammatical_category = random.choice(list(question.other_grammatical_categories.keys()))  # noqa: S311 # nosec
-            other_label = question.other_grammatical_categories[other_grammatical_category]
+            other_category = random.choice(list(question.other_grammatical_categories.keys()))  # noqa: S311 # nosec
+            other_label = question.other_grammatical_categories[other_category]
             also = " also" if str(question) == str(other_label) else ""
             question_str = quoted(linkified(str(question)))
             other_label_str = quoted(linkified(str(other_label)))
-            notes.append(f"The {other_grammatical_category} of {question_str} is{also} {other_label_str}.")
+            notes.append(f"The {other_category} of {question_str} is{also} {other_label_str}.")
         return tuple(notes)
 
     def _include_grammatical_notes(self) -> bool:

--- a/src/toisto/ui/format.py
+++ b/src/toisto/ui/format.py
@@ -1,5 +1,6 @@
 """Formatting."""
 
+from collections.abc import Sequence
 from datetime import datetime, timedelta
 
 from toisto.model.language.label import Label
@@ -75,7 +76,7 @@ def enumerated(*texts: str, min_enumeration_length: int = 2) -> str:
             return ""
 
 
-def wrapped(text: str, style: str, postfix: str = "\n") -> str:
+def wrapped(text: str, *, style: str, postfix: str = "\n") -> str:
     """Return the text wrapped with the style."""
     return f"[{style}]{text}[/{style}]{postfix}"
 
@@ -83,3 +84,16 @@ def wrapped(text: str, style: str, postfix: str = "\n") -> str:
 def linkified_and_enumerated(*texts: str) -> str:
     """Return a linkified and enumerated version of the texts."""
     return enumerated(*(f"{quoted(linkified(text))}" for text in texts))
+
+
+def bulleted_list(label: str, items: Sequence[str], style: str, *, bullet: str = "-") -> str:
+    """Create a bulleted list of the items."""
+    items = [punctuated(item) for item in items]
+    match len(items):
+        case 0:
+            return ""
+        case 1:
+            text = f"{label}: {items[0]}"
+        case _:
+            text = f"{label}s:\n" + "\n".join(f"{bullet} {item}" for item in items)
+    return wrapped(text, style=style)

--- a/src/toisto/ui/style.py
+++ b/src/toisto/ui/style.py
@@ -9,7 +9,12 @@ theme = Theme(
         "language": "light_goldenrod2 bold",
         "progress": "light_sky_blue3",
         "quiz": "medium_purple1",
+        "answer": "grey69",
         "secondary": "grey69",
+        "colloquial": "grey69",
+        "example": "grey69",
+        "meaning": "grey69",
+        "note": "grey69",
         "retention": "grey50",
     }
 )

--- a/tests/toisto/command/test_practice.py
+++ b/tests/toisto/command/test_practice.py
@@ -231,7 +231,7 @@ class PracticeFeedbackTest(PracticeBase):
         concept = self.create_concept_fixture()
         quizzes = create_quizzes(FI_NL, (DICTATE,), concept)
         patched_print = self.practice(FI_NL, quizzes)
-        self.assert_printed(f"{Feedback.CORRECT}[secondary]Meaning '{linkified('Hoi!')}'[/secondary]\n", patched_print)
+        self.assert_printed(f"{Feedback.CORRECT}[meaning]Meaning '{linkified('Hoi!')}'[/meaning]\n", patched_print)
 
     @patch("builtins.input", Mock(return_value="talot\n"))
     def test_quiz_with_multiple_meanings(self):
@@ -240,8 +240,8 @@ class PracticeFeedbackTest(PracticeBase):
         quizzes = create_quizzes(FI_NL, (PLURAL,), concept)
         patched_print = self.practice(FI_NL, quizzes)
         expected_feedback = (
-            f"{Feedback.CORRECT}[secondary]Meaning '{linkified('huis')}', "
-            f"respectively '{linkified('huizen')}'.[/secondary]\n"
+            f"{Feedback.CORRECT}[meaning]Meaning '{linkified('huis')}', "
+            f"respectively '{linkified('huizen')}'.[/meaning]\n"
         )
         self.assert_printed(expected_feedback, patched_print)
 
@@ -252,7 +252,7 @@ class PracticeFeedbackTest(PracticeBase):
         quizzes = create_quizzes(FI_NL, (READ,), concept)
         patched_print = self.practice(FI_NL, quizzes)
         expected_feedback = (
-            f"{Feedback.CORRECT}[secondary]Another correct answer is '{linkified('zij rijdt')}'.[/secondary]\n"
+            f"{Feedback.CORRECT}[answer]Another correct answer is '{linkified('zij rijdt')}'.[/answer]\n"
         )
         self.assert_printed(expected_feedback, patched_print)
 
@@ -262,7 +262,7 @@ class PracticeFeedbackTest(PracticeBase):
         concept = self.create_concept_fixture("gender")
         quizzes = create_quizzes(FI_NL, (INTERPRET,), concept)
         patched_print = self.practice(FI_NL, quizzes)
-        expected_feedback = f"{Feedback.CORRECT}[secondary]Meaning '{linkified('hän ajaa')}'.[/secondary]\n"
+        expected_feedback = f"{Feedback.CORRECT}[meaning]Meaning '{linkified('hän ajaa')}'.[/meaning]\n"
         self.assert_printed(expected_feedback, patched_print)
 
     @patch("builtins.input", Mock(return_value="vieressä\n"))
@@ -282,9 +282,9 @@ class PracticeFeedbackTest(PracticeBase):
         )
         quizzes = create_quizzes(FI_NL, (DICTATE,), concept)
         patched_print = self.practice(FI_NL, quizzes)
-        expected_feedback = f"""{Feedback.CORRECT}[secondary]Meaning '{linkified("naast")}'.[/secondary]
-[secondary]Example: '{linkified("Museo on kirkon vieressä.")}' meaning '{linkified("Het museum is naast de kerk.")}'\
-[/secondary]
+        expected_feedback = f"""{Feedback.CORRECT}[meaning]Meaning '{linkified("naast")}'.[/meaning]
+[example]Example: '{linkified("Museo on kirkon vieressä.")}' meaning '{linkified("Het museum is naast de kerk.")}'\
+[/example]
 """
         self.assert_printed(expected_feedback, patched_print)
 
@@ -309,10 +309,10 @@ class PracticeFeedbackTest(PracticeBase):
         )
         quizzes = create_quizzes(FI_NL, (DICTATE,), concept)
         patched_print = self.practice(FI_NL, quizzes)
-        expected_feedback = f"""{Feedback.CORRECT}[secondary]Meaning '{linkified("zwart")}'.[/secondary]
-[secondary]Examples:
+        expected_feedback = f"""{Feedback.CORRECT}[meaning]Meaning '{linkified("zwart")}'.[/meaning]
+[example]Examples:
 - '{linkified("Auto on musta.")}' meaning '{linkified("De auto is zwart.")}'
-- '{linkified("Autot ovat mustia.")}' meaning '{linkified("De auto's zijn zwart.")}'[/secondary]
+- '{linkified("Autot ovat mustia.")}' meaning '{linkified("De auto's zijn zwart.")}'[/example]
 """
         self.assert_printed(expected_feedback, patched_print)
 
@@ -323,10 +323,10 @@ class PracticeFeedbackTest(PracticeBase):
         quizzes = create_quizzes(FI_NL, (DICTATE,), concept)
         quizzes = Quizzes(quiz for quiz in quizzes if quiz.answer == Label(FI, "pöytävalaisin"))
         patched_print = self.practice(FI_NL, quizzes)
-        expected_feedback = f"""{Feedback.CORRECT}[secondary]Meaning '{linkified("de tafellamp")}'.[/secondary]
-[secondary]Examples:
+        expected_feedback = f"""{Feedback.CORRECT}[meaning]Meaning '{linkified("de tafellamp")}'.[/meaning]
+[example]Examples:
 - '{linkified("Minä etsin pöytälamppua.")}' meaning '{linkified("Ik zoek een tafellamp.")}'
-- '{linkified("Minä etsin pöytävalaisinta.")}' meaning '{linkified("Ik zoek een tafellamp.")}'[/secondary]
+- '{linkified("Minä etsin pöytävalaisinta.")}' meaning '{linkified("Ik zoek een tafellamp.")}'[/example]
 """
         self.assert_printed(expected_feedback, patched_print)
 
@@ -337,9 +337,9 @@ class PracticeFeedbackTest(PracticeBase):
         quizzes = create_quizzes(NL_FI, (DICTATE,), concept)
         patched_print = self.practice(NL_FI, quizzes)
         expected_feedback = f"""{Feedback.CORRECT}\
-[secondary]Meaning '{linkified("pöytälamppu")}' and '{linkified("pöytävalaisin")}'.[/secondary]
-[secondary]Example: '{linkified("Ik zoek een tafellamp.")}' meaning '{linkified("Minä etsin pöytälamppua.")}' and \
-'{linkified("Minä etsin pöytävalaisinta.")}'[/secondary]
+[meaning]Meaning '{linkified("pöytälamppu")}' and '{linkified("pöytävalaisin")}'.[/meaning]
+[example]Example: '{linkified("Ik zoek een tafellamp.")}' meaning '{linkified("Minä etsin pöytälamppua.")}' and \
+'{linkified("Minä etsin pöytävalaisinta.")}'[/example]
 """
         self.assert_printed(expected_feedback, patched_print)
 
@@ -364,9 +364,9 @@ class PracticeFeedbackTest(PracticeBase):
         quizzes = create_quizzes(FI_NL, (ANTONYM,), son)
         patched_print = self.practice(FI_NL, quizzes)
         expected_feedback = f"""{Feedback.INCORRECT}The correct answer is '[inserted]{linkified("tytär")}[/inserted]'.
-[secondary]Another correct answer is '{linkified("isä")}'.[/secondary]
-[secondary]Meaning '{linkified("de zoon")}', respectively '{linkified("de dochter")}' and '{linkified("de vader")}'.\
-[/secondary]
+[answer]Another correct answer is '{linkified("isä")}'.[/answer]
+[meaning]Meaning '{linkified("de zoon")}', respectively '{linkified("de dochter")}' and '{linkified("de vader")}'.\
+[/meaning]
 """
         self.assert_printed(expected_feedback, patched_print)
 

--- a/tests/toisto/ui/test_text.py
+++ b/tests/toisto/ui/test_text.py
@@ -68,8 +68,8 @@ class FeedbackTest(ToistoTestCase):
                 {"label": "kiitti", "language": FI, "colloquial": True},
             ],
         )
-        colloquial = f"[secondary]The colloquial Finnish spoken was '{linkified('kiitti')}'.[/secondary]\n"
-        meaning = f"[secondary]Meaning '{linkified('dank')}'.[/secondary]\n"
+        colloquial = f"[colloquial]The colloquial Finnish spoken was '{linkified('kiitti')}'.[/colloquial]\n"
+        meaning = f"[meaning]Meaning '{linkified('dank')}'.[/meaning]\n"
         answer = f"The correct answer is '[inserted]{linkified('kiitos')}[/inserted]'.\n"
         expected_feedback_correct = Feedback.CORRECT + colloquial + meaning
         expected_feedback_incorrect = Feedback.INCORRECT + answer + colloquial + meaning
@@ -97,9 +97,7 @@ class FeedbackTest(ToistoTestCase):
         )
         quiz = create_quizzes(NL_FI, (READ,), concept).pop()
         expected_other_answer = linkified(str(quiz.other_answers(GUESS)[0]))
-        expected_text = (
-            f"{Feedback.CORRECT}[secondary]Another correct answer is '{expected_other_answer}'.[/secondary]\n"
-        )
+        expected_text = f"{Feedback.CORRECT}[answer]Another correct answer is '{expected_other_answer}'.[/answer]\n"
         feedback = Feedback(quiz, NL_FI)
         self.assertIn(expected_text, feedback.text(Evaluation.CORRECT, GUESS, Retention()))
 
@@ -116,7 +114,7 @@ class FeedbackTest(ToistoTestCase):
         )
         quiz = create_quizzes(NL_FI, (READ,), concept).pop()
         other_answers = enumerated(*[f"'{linkified(str(answer))}'" for answer in quiz.other_answers(GUESS)])
-        expected_text = f"{Feedback.CORRECT}[secondary]Other correct answers are {other_answers}.[/secondary]\n"
+        expected_text = f"{Feedback.CORRECT}[answer]Other correct answers are {other_answers}.[/answer]\n"
         feedback = Feedback(quiz, NL_FI)
         self.assertIn(expected_text, feedback.text(Evaluation.CORRECT, GUESS, Retention()))
 
@@ -128,7 +126,7 @@ class FeedbackTest(ToistoTestCase):
         quiz = create_quizzes(FI_NL, (DICTATE,), concept).pop()
         expected_text = (
             f"{Feedback.INCORRECT}The correct answer is '[inserted]{linkified('terve')}[/inserted]'.\n"
-            f"[secondary]Meaning '{linkified('hoi')}'.[/secondary]\n"
+            f"[meaning]Meaning '{linkified('hoi')}'.[/meaning]\n"
         )
         feedback = Feedback(quiz, FI_NL)
         self.assertIn(expected_text, feedback.text(Evaluation.INCORRECT, Label(FI, "incorrect"), Retention()))
@@ -146,7 +144,7 @@ class FeedbackTest(ToistoTestCase):
         quiz = create_quizzes(NL_FI, (READ,), concept).pop()
         expected_text = (
             f"{Feedback.INCORRECT}The correct answer is '[inserted]{linkified('terve')}[/inserted]'.\n"
-            f"[secondary]Another correct answer is '{linkified('hei')}'.[/secondary]\n"
+            f"[answer]Another correct answer is '{linkified('hei')}'.[/answer]\n"
         )
         feedback = Feedback(quiz, NL_FI)
         self.assertIn(expected_text, feedback.text(Evaluation.INCORRECT, Label(FI, "incorrect"), Retention()))
@@ -178,7 +176,7 @@ class FeedbackTest(ToistoTestCase):
         )
         quiz = create_quizzes(FI_NL, (DICTATE,), concept).pop()
         expected_text = (
-            f"The correct answer is '{linkified('terve')}'.\n[secondary]Meaning '{linkified('hoi')}'.[/secondary]\n"
+            f"The correct answer is '{linkified('terve')}'.\n[meaning]Meaning '{linkified('hoi')}'.[/meaning]\n"
         )
         feedback = Feedback(quiz, FI_NL)
         self.assertIn(expected_text, feedback.text(Evaluation.SKIPPED, Label(FI, "?"), Retention()))
@@ -210,7 +208,7 @@ class FeedbackNotesTest(ToistoTestCase):
         quiz = create_quizzes(NL_FI, (DICTATE,), concept).pop()
         feedback = Feedback(quiz, NL_FI)
         self.assertIn(
-            "[secondary]Note: 'Hoi' is an informal greeting.[/secondary]",
+            "[note]Note: 'Hoi' is an informal greeting.[/note]",
             feedback.text(Evaluation.CORRECT, Label(NL, "hoi"), Retention()),
         )
 
@@ -225,7 +223,7 @@ class FeedbackNotesTest(ToistoTestCase):
         quiz = create_quizzes(FI_NL, (DICTATE,), concept).pop()
         feedback = Feedback(quiz, FI_NL)
         self.assertIn(
-            "[secondary]Notes:\n- Moi is an informal greeting.\n- 'Moi moi' means goodbye.[/secondary]\n",
+            "[note]Notes:\n- Moi is an informal greeting.\n- 'Moi moi' means goodbye.[/note]\n",
             feedback.text(Evaluation.CORRECT, Label(FI, "moi"), Retention()),
         )
 
@@ -237,7 +235,7 @@ class FeedbackNotesTest(ToistoTestCase):
         quiz = create_quizzes(FI_NL, (DICTATE,), concept).pop()
         feedback = Feedback(quiz, FI_NL)
         self.assertIn(
-            "[secondary]Note: 'Moi' is an informal greeting.[/secondary]",
+            "[note]Note: 'Moi' is an informal greeting.[/note]",
             feedback.text(Evaluation.INCORRECT, Label(FI, "toi"), Retention()),
         )
 
@@ -255,8 +253,7 @@ class FeedbackNotesTest(ToistoTestCase):
         feedback = Feedback(quiz, FI_NL)
         feedback.incorrect_guesses = [Label(NL, "hallo")]
         self.assertIn(
-            f"[secondary]Note: Your incorrect answer '{linkified('hallo')}' is "
-            f"'{linkified('terve')}' in Finnish.[/secondary]",
+            f"[note]Note: Your incorrect answer '{linkified('hallo')}' is '{linkified('terve')}' in Finnish.[/note]",
             feedback.text(Evaluation.CORRECT, Label(NL, "hoi"), Retention()),
         )
 
@@ -274,8 +271,7 @@ class FeedbackNotesTest(ToistoTestCase):
         feedback = Feedback(quiz, FI_NL)
         feedback.incorrect_guesses = [Label(NL, "hallo")]
         self.assertIn(
-            f"[secondary]Note: Your incorrect answer '{linkified('hallo')}' is "
-            f"'{linkified('terve')}' in Finnish.[/secondary]",
+            f"[note]Note: Your incorrect answer '{linkified('hallo')}' is '{linkified('terve')}' in Finnish.[/note]",
             feedback.text(Evaluation.INCORRECT, Label(NL, "hallo"), Retention()),
         )
 
@@ -293,8 +289,7 @@ class FeedbackNotesTest(ToistoTestCase):
         feedback = Feedback(quiz, FI_NL)
         feedback.incorrect_guesses = [Label(NL, "huis")]
         self.assertIn(
-            f"[secondary]Note: Your incorrect answer '{linkified('huis')}' is "
-            f"'{linkified('talo')}' in Finnish.[/secondary]",
+            f"[note]Note: Your incorrect answer '{linkified('huis')}' is '{linkified('talo')}' in Finnish.[/note]",
             feedback.text(Evaluation.CORRECT, Label(NL, "thuis"), Retention()),
         )
 
@@ -315,8 +310,7 @@ class FeedbackNotesTest(ToistoTestCase):
         feedback = Feedback(quiz, FI_NL)
         feedback.incorrect_guesses = [Label(NL, "huizen")]
         self.assertIn(
-            f"[secondary]Note: Your incorrect answer '{linkified('huizen')}' is "
-            f"'{linkified('talot')}' in Finnish.[/secondary]",
+            f"[note]Note: Your incorrect answer '{linkified('huizen')}' is '{linkified('talot')}' in Finnish.[/note]",
             feedback.text(Evaluation.CORRECT, Label(NL, "thuis"), Retention()),
         )
 
@@ -328,7 +322,7 @@ class FeedbackNotesTest(ToistoTestCase):
         quiz = create_quizzes(FI_NL, (DICTATE,), concept).pop()
         feedback = Feedback(quiz, FI_NL)
         self.assertIn(
-            "[secondary]Note: 'Moi' is an informal greeting.[/secondary]",
+            "[note]Note: 'Moi' is an informal greeting.[/note]",
             feedback.text(Evaluation.SKIPPED, Label(FI, "?"), Retention()),
         )
 
@@ -398,7 +392,7 @@ class FeedbackMeaningTest(ToistoTestCase):
         for quiz in create_quizzes(FI_NL, (INTERPRET,), engineer):
             feedback = Feedback(quiz, FI_NL)
             self.assertIn(
-                f"[secondary]Meaning '{linkified(str(quiz.question))}'.[/secondary]\n",
+                f"[meaning]Meaning '{linkified(str(quiz.question))}'.[/meaning]\n",
                 feedback.text(Evaluation.CORRECT, Label(NL, "ingenieur"), Retention()),
             )
 
@@ -421,7 +415,7 @@ class FeedbackExampleTest(ToistoTestCase):
         feedback = Feedback(quiz, FI_NL)
         self.assertIn(
             Feedback.CORRECT
-            + (f"[secondary]Example: '{linkified('Moi Alice!')}' meaning '{linkified('Hoi Alice!')}'[/secondary]\n"),
+            + (f"[example]Example: '{linkified('Moi Alice!')}' meaning '{linkified('Hoi Alice!')}'[/example]\n"),
             feedback.text(Evaluation.CORRECT, Label(NL, "hoi"), Retention()),
         )
 
@@ -439,7 +433,7 @@ class FeedbackExampleTest(ToistoTestCase):
         feedback = Feedback(quiz, FI_NL)
         self.assertIn(
             Feedback.CORRECT
-            + (f"[secondary]Example: '{linkified('Terve Alice!')}' meaning '{linkified('Hoi Alice!')}'[/secondary]\n"),
+            + (f"[example]Example: '{linkified('Terve Alice!')}' meaning '{linkified('Hoi Alice!')}'[/example]\n"),
             feedback.text(Evaluation.CORRECT, GUESS, Retention()),
         )
 
@@ -462,8 +456,8 @@ class FeedbackExampleTest(ToistoTestCase):
         feedback = Feedback(quiz, FI_NL)
         self.assertIn(
             Feedback.CORRECT
-            + f"[secondary]Example: '{linkified('Terve Alice!')}' meaning '{linkified('Hoi Alice!')}' and "
-            f"'{linkified('Hallo Alice!')}'[/secondary]\n",
+            + f"[example]Example: '{linkified('Terve Alice!')}' meaning '{linkified('Hoi Alice!')}' and "
+            f"'{linkified('Hallo Alice!')}'[/example]\n",
             feedback.text(Evaluation.CORRECT, GUESS, Retention()),
         )
 
@@ -485,10 +479,10 @@ class FeedbackExampleTest(ToistoTestCase):
         )
         quiz = create_quizzes(FI_NL, (WRITE,), hi).pop()
         feedback = Feedback(quiz, FI_NL)
-        expected_feedback = f"""{Feedback.CORRECT}[secondary]Examples:
+        expected_feedback = f"""{Feedback.CORRECT}[example]Examples:
 - '{linkified("Terve Alice!")}' meaning '{linkified("Hallo Alice!")}' and '{linkified("Hoi Alice!")}' (colloquial).
 - '{linkified("Moi Alice!")}' (colloquial) meaning '{linkified("Hallo Alice!")}' and '{linkified("Hoi Alice!")}' \
-(colloquial).[/secondary]
+(colloquial).[/example]
 """
         self.assertIn(expected_feedback, feedback.text(Evaluation.CORRECT, GUESS, Retention()))
 
@@ -514,8 +508,8 @@ class FeedbackExampleTest(ToistoTestCase):
         quiz = create_quizzes(FI_NL, (READ,), near).pop()
         feedback = Feedback(quiz, FI_NL)
         expected_feedback = f"""{Feedback.CORRECT}\
-[secondary]Another correct answer is '{linkified("dichtbij")}'.[/secondary]
-[secondary]Example: '{linkified("Se on lähellä.")}' meaning '{linkified("Het is dichtbij.")}' and \
-'{linkified("Het is in de buurt.")}'[/secondary]
+[answer]Another correct answer is '{linkified("dichtbij")}'.[/answer]
+[example]Example: '{linkified("Se on lähellä.")}' meaning '{linkified("Het is dichtbij.")}' and \
+'{linkified("Het is in de buurt.")}'[/example]
 """
         self.assertIn(expected_feedback, feedback.text(Evaluation.CORRECT, Label(NL, "in de buurt"), Retention()))


### PR DESCRIPTION
Use separate styles for meanings, notes, colloquial labels, other answers, and examples.