### PR TITLE
Enumerate correct answers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
+- When the user answers incorrectly and none of the correct answers are similar to the guess, list all correct answers instead of differentiating between one correct answer and other correct answers. Fixes [#1135](https://github.com/fniessink/toisto/issues/1135).
 - Don't show an answer as another correct answer if the user's answer was a generated alternative. Fixes [#1136](https://github.com/fniessink/toisto/issues/1136).
 
 ## 0.38.0 - 2025-09-14

--- a/src/toisto/model/language/translation.py
+++ b/src/toisto/model/language/translation.py
@@ -1,5 +1,7 @@
 """Translating labels."""
 
+from toisto.tools import unique
+
 from . import Language
 from .concept import Concept
 from .label import Label, Labels
@@ -9,10 +11,10 @@ def meanings(source_label: Label, target_language: Language) -> Labels:
     """Return the meanings of the source label in the target language."""
     source_language = source_label.language
     return Labels(
-        [
+        unique(
             meaning
             for concept in Concept.instances.get_all_values()
             for label in concept.labels(source_language).matching(source_label)
             for meaning in concept.meanings(target_language).with_same_grammatical_categories_as(label)
-        ]
+        )
     )

--- a/src/toisto/ui/diff.py
+++ b/src/toisto/ui/diff.py
@@ -2,8 +2,6 @@
 
 from difflib import SequenceMatcher
 
-from .dictionary import linkified
-
 
 def show_whitespace(text: str) -> str:
     """Make whitespace visible so it can be colored."""
@@ -20,11 +18,9 @@ def deleted(old_text: str) -> str:
     return f"[deleted]{show_whitespace(old_text)}[/deleted]"
 
 
-def colored_diff(old_text: str, new_text: str, min_ratio_for_diff: float = 0.6) -> str:
+def colored_diff(old_text: str, new_text: str) -> str:
     """Return a colored string showing the diffs between old and new text."""
     matcher = SequenceMatcher(a=old_text.lower(), b=new_text.lower())
-    if matcher.ratio() < min_ratio_for_diff:
-        return inserted(linkified(new_text))
     result = ""
     for operator, old_start, old_end, new_start, new_end in matcher.get_opcodes():
         old_fragment, new_fragment = (old_text[old_start:old_end], new_text[new_start:new_end])

--- a/tests/toisto/command/test_practice.py
+++ b/tests/toisto/command/test_practice.py
@@ -363,8 +363,8 @@ class PracticeFeedbackTest(PracticeBase):
         )
         quizzes = create_quizzes(FI_NL, (ANTONYM,), son)
         patched_print = self.practice(FI_NL, quizzes)
-        expected_feedback = f"""{Feedback.INCORRECT}The correct answer is '[inserted]{linkified("tytär")}[/inserted]'.
-[answer]Another correct answer is '{linkified("isä")}'.[/answer]
+        expected_feedback = f"""\
+{Feedback.INCORRECT}The correct answers are '{linkified("tytär")}' and '{linkified("isä")}'.
 [meaning]Meaning '{linkified("de zoon")}', respectively '{linkified("de dochter")}' and '{linkified("de vader")}'.\
 [/meaning]
 """

--- a/tests/toisto/ui/test_diff.py
+++ b/tests/toisto/ui/test_diff.py
@@ -2,7 +2,6 @@
 
 import unittest
 
-from toisto.ui.dictionary import linkified
 from toisto.ui.diff import colored_diff
 
 
@@ -15,7 +14,10 @@ class DiffTest(unittest.TestCase):
 
     def test_wildly_different_strings(self):
         """Test that wildly different strings are green."""
-        self.assertEqual(f"[inserted]{linkified('different')}[/inserted]", colored_diff("completely", "different"))
+        self.assertEqual(
+            "[inserted]diff[/inserted]e[inserted]ren[/inserted]t[deleted]ely[/deleted]",
+            colored_diff("completely", "different"),
+        )
 
     def test_text_deleted(self):
         """Test that deleted parts are red."""
@@ -49,4 +51,4 @@ class DiffTest(unittest.TestCase):
 
     def test_make_inserted_whitespace_not_visible(self):
         """Test that inserted whitespace is not made visible."""
-        self.assertEqual(f"[inserted]{linkified('de morgen')}[/inserted]", colored_diff("uhm", "de morgen"))
+        self.assertEqual("[inserted]de [/inserted]m[inserted]orgen[/inserted]", colored_diff("uhm", "de morgen"))

--- a/tests/toisto/ui/test_text.py
+++ b/tests/toisto/ui/test_text.py
@@ -70,7 +70,7 @@ class FeedbackTest(ToistoTestCase):
         )
         colloquial = f"[colloquial]The colloquial Finnish spoken was '{linkified('kiitti')}'.[/colloquial]\n"
         meaning = f"[meaning]Meaning '{linkified('dank')}'.[/meaning]\n"
-        answer = f"The correct answer is '[inserted]{linkified('kiitos')}[/inserted]'.\n"
+        answer = f"The correct answer is '{linkified('kiitos')}'.\n"
         expected_feedback_correct = Feedback.CORRECT + colloquial + meaning
         expected_feedback_incorrect = Feedback.INCORRECT + answer + colloquial + meaning
         expected_feedback_on_skip = f"The correct answer is '{linkified('kiitos')}'.\n" + colloquial + meaning
@@ -125,7 +125,7 @@ class FeedbackTest(ToistoTestCase):
         )
         quiz = create_quizzes(FI_NL, (DICTATE,), concept).pop()
         expected_text = (
-            f"{Feedback.INCORRECT}The correct answer is '[inserted]{linkified('terve')}[/inserted]'.\n"
+            f"{Feedback.INCORRECT}The correct answer is '{linkified('terve')}'.\n"
             f"[meaning]Meaning '{linkified('hoi')}'.[/meaning]\n"
         )
         feedback = Feedback(quiz, FI_NL)
@@ -143,8 +143,7 @@ class FeedbackTest(ToistoTestCase):
         )
         quiz = create_quizzes(NL_FI, (READ,), concept).pop()
         expected_text = (
-            f"{Feedback.INCORRECT}The correct answer is '[inserted]{linkified('terve')}[/inserted]'.\n"
-            f"[answer]Another correct answer is '{linkified('hei')}'.[/answer]\n"
+            f"{Feedback.INCORRECT}The correct answers are '{linkified('terve')}' and '{linkified('hei')}'.\n"
         )
         feedback = Feedback(quiz, NL_FI)
         self.assertIn(expected_text, feedback.text(Evaluation.INCORRECT, Label(FI, "incorrect"), Retention()))
@@ -155,7 +154,7 @@ class FeedbackTest(ToistoTestCase):
             "house", labels=[{"label": "het huis", "language": NL}, {"label": "talo", "language": FI}]
         )
         quiz = create_quizzes(FI_NL, (READ,), concept).pop()
-        expected_text = f"{Feedback.INCORRECT}The correct answer is '[inserted]{linkified('het huis')}[/inserted]'.\n"
+        expected_text = f"{Feedback.INCORRECT}The correct answer is '{linkified('het huis')}'.\n"
         feedback = Feedback(quiz, FI_NL)
         self.assertIn(expected_text, feedback.text(Evaluation.INCORRECT, Label(NL, "incorrect"), Retention()))
 


### PR DESCRIPTION
When the user answers incorrectly and none of the correct answers are similar to the guess, list all correct answers instead of differentiating between one correct answer and other correct answers.

Fixes #1135.