### PR TITLE
Add a missing alternative spelling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Toisto will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Add "hersens" as alternative spelling for brain in Dutch. Fixes [#1169](https://github.com/fniessink/toisto/issues/1169).
+
 ## 0.40.0 - 2025-09-28
 
 ### Fixed

--- a/src/concepts/nouns/brain.json
+++ b/src/concepts/nouns/brain.json
@@ -21,7 +21,10 @@
         "nl": [
             {
                 "concept": "brain",
-                "label": "de hersenen"
+                "label": [
+                    "de hersenen",
+                    "de hersens"
+                ]
             }
         ]
     }


### PR DESCRIPTION
Add "hersens" as alternative spelling for brain in Dutch.

Fixes #1169.