### PR TITLE
Don't repeat homographs in notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 
 ### Fixed
 
+- When giving the meaning of incorrect answers, don't repeat labels that are homographs. Fixes [#1174](https://github.com/fniessink/toisto/issues/1174).
 - Add "hersens" as alternative spelling for brain in Dutch. Fixes [#1169](https://github.com/fniessink/toisto/issues/1169).
 
 ## 0.40.0 - 2025-09-28

--- a/src/toisto/model/language/label.py
+++ b/src/toisto/model/language/label.py
@@ -11,7 +11,7 @@ from random import shuffle
 from typing import ClassVar
 
 from toisto.match import match
-from toisto.tools import first, first_upper
+from toisto.tools import first, first_upper, unique
 
 from . import Language
 from .grammatical_category import GrammaticalCategory
@@ -338,8 +338,7 @@ class Labels:  # noqa: PLW1641
     @property
     def compounds(self) -> Labels:
         """Return the compounds of the labels."""
-        compounds = [label.compounds for label in self._labels]
-        return Labels(chain(*compounds))
+        return Labels(chain(*[label.compounds for label in self._labels]))
 
     @property
     def cloze_tests(self) -> Labels:
@@ -348,5 +347,5 @@ class Labels:  # noqa: PLW1641
 
     @property
     def as_strings(self) -> tuple[str, ...]:
-        """Return the labels as strings."""
-        return tuple(str(label) for label in self._labels)
+        """Return the labels as strings, without duplicates."""
+        return tuple(unique(str(label) for label in self._labels))

--- a/tests/toisto/ui/test_text.py
+++ b/tests/toisto/ui/test_text.py
@@ -208,6 +208,27 @@ class FeedbackNotesTest(ToistoTestCase):
             feedback.text(Evaluation.CORRECT, "hoi", Retention()),
         )
 
+    def test_note_on_incorrect_answer_that_has_homograph_meanings(self):
+        """Test that the note is given when the answer has two meanings that are homographs."""
+        less = self.create_concept(
+            "less", labels=[{"label": "vähemmän", "language": FI}, {"label": "minder", "language": NL}]
+        )
+        self.create_concept("elder", labels=[{"label": "vanhempi", "language": FI}, {"label": "ouder", "language": NL}])
+        self.create_concept(
+            "older",
+            labels=[
+                {"label": {"comparative degree": "vanhempi"}, "language": FI},
+                {"label": {"comparative degree": "ouder"}, "language": NL},
+            ],
+        )
+        quiz = create_quizzes(FI_NL, (INTERPRET,), less).pop()
+        feedback = Feedback(quiz, FI_NL)
+        feedback.incorrect_guesses = ["ouder"]
+        self.assertIn(
+            f"[note]Note: Your incorrect answer '{linkified('ouder')}' is '{linkified('vanhempi')}' in Finnish.[/note]",
+            feedback.text(Evaluation.CORRECT, "minder", Retention()),
+        )
+
     def test_note_on_incorrect_answer_that_has_different_meaning_that_is_repeated(self):
         """Test that the note is not repeated if the same incorrect answer is given twice."""
         self.create_concept("hello", labels=[TERVE, {"label": "hallo", "language": NL}])


### PR DESCRIPTION
When giving the meaning of incorrect answers, don't repeat labels that are homographs.

Fixes #1174.