### PR TITLE
Fix useless tip for cloze test quizzes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Add 'hersens' as alternative spelling in Dutch for 'brain'. Fixes [#1169](https://github.com/fniessink/toisto/issues/1169).
 - When giving the meaning of incorrect answers, don't repeat labels that are homographs. Fixes [#1174](https://github.com/fniessink/toisto/issues/1174).
 - Add 'wateren' as alternative spelling in Dutch for 'waters'. Fixes [#1175](https://github.com/fniessink/toisto/issues/1175).
+- Cloze test quizzes would get a useless tip when presented multiple times. Fixes [#1176](https://github.com/fniessink/toisto/issues/1176).
 - Limit the number of examples shown to three per quiz. Fixes [#1180](https://github.com/fniessink/toisto/issues/1180).
 
 ## 0.40.0 - 2025-09-28

--- a/src/toisto/model/language/label.py
+++ b/src/toisto/model/language/label.py
@@ -183,7 +183,7 @@ class Label:
         """Return the label compounds."""
         return Labels(label for label in chain(*self.homograph_mapping.values()) if self in label.roots)
 
-    @property
+    @cached_property
     def cloze_tests(self) -> Labels:
         """Return the cloze tests."""
         return Labels(Label(self.language, cloze_test) for cloze_test in self._cloze_tests)


### PR DESCRIPTION
Cloze test quizzes would get a useless tip when presented multiple times.

Fixes #1176.