### PR TITLE
Don't repeat homographs in the help information

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 - Add 'wateren' as alternative spelling in Dutch for 'waters'. Fixes [#1175](https://github.com/fniessink/toisto/issues/1175).
 - Cloze test quizzes would get a useless tip when presented multiple times. Fixes [#1176](https://github.com/fniessink/toisto/issues/1176).
 - Limit the number of examples shown to three per quiz. Fixes [#1180](https://github.com/fniessink/toisto/issues/1180).
+- When running `toisto practice --help`, don't repeat homographs in the list of concepts. Fixes [#1183](https://github.com/fniessink/toisto/issues/1183).
 
 ## 0.40.0 - 2025-09-28
 

--- a/src/toisto/ui/cli.py
+++ b/src/toisto/ui/cli.py
@@ -115,7 +115,7 @@ class CommandBuilder:
             and not concept.answer_only
         }
         language = self.get_target_language()
-        all_labels = sorted(str(first(labels)) for concept in concepts if (labels := concept.labels(language)))
+        all_labels = sorted({str(first(labels)) for concept in concepts if (labels := concept.labels(language))})
         parser.add_argument(
             "concepts",
             metavar="{concept}",


### PR DESCRIPTION
When running `toisto practice --help`, don't repeat homographs in the list of concepts.

Fixes #1183.