### PR TITLE
Fix missing meaning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Fixed
 
 - Toisto was not working on iOS and iPadOS because the Pygame community edition does not install. Fixed by removing the dependency on Pygame and requiring an mp3 player on Windows.
+- Show meaning when quizzing a label that has a diminutive in one language, but not the other. Fixes [#1167](https://github.com/fniessink/toisto/issues/1167).
 
 ### Changed
 

--- a/src/toisto/model/language/grammatical_category.py
+++ b/src/toisto/model/language/grammatical_category.py
@@ -30,3 +30,5 @@ GrammaticalCategory = Literal[
     Number,
     Abbreviation,
 ]
+
+DEFAULT_CATEGORIES: frozenset[GrammaticalCategory] = frozenset({"root", "full form"})

--- a/src/toisto/model/language/label.py
+++ b/src/toisto/model/language/label.py
@@ -14,7 +14,7 @@ from toisto.match import match
 from toisto.tools import first, first_upper, unique
 
 from . import Language
-from .grammatical_category import GrammaticalCategory
+from .grammatical_category import DEFAULT_CATEGORIES, GrammaticalCategory
 from .grammatical_form import GrammaticalForm
 
 SpellingAlternatives = dict[Language, dict[re.Pattern[str], str]]
@@ -194,8 +194,8 @@ class Label:
 
     def has_same_grammatical_form(self, other: Label) -> bool:
         """Return whether this label has the same grammatical form as the other label."""
-        self_grammatical_categories = self.grammatical_form.grammatical_categories
-        other_grammatical_categories = other.grammatical_form.grammatical_categories
+        self_grammatical_categories = self.grammatical_form.grammatical_categories - DEFAULT_CATEGORIES
+        other_grammatical_categories = other.grammatical_form.grammatical_categories - DEFAULT_CATEGORIES
         return (
             self_grammatical_categories == other_grammatical_categories
             or (not self_grammatical_categories and other.is_grammatical_base)


### PR DESCRIPTION
Show meaning when quizzing a label that has a diminutive in one language, but not the other.

Fixes #1167.