### PR TITLE
Pause after incorrect/skipped answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to Toisto will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Wait for the user to press Enter after an incorrectly answered or skipped quiz before showing the next quiz, so the correct answer can be read. Fixes [#1283](https://github.com/fniessink/toisto/issues/1283).
+
 ## 0.42.0 - 2026-06-06
 
 ### Fixed

--- a/src/toisto/command/practice.py
+++ b/src/toisto/command/practice.py
@@ -14,7 +14,7 @@ from toisto.model.quiz.quiz_type import ListenOnlyQuizType
 from toisto.persistence.progress import save_progress
 from toisto.ui.dictionary import linkified
 from toisto.ui.speech import Speech
-from toisto.ui.text import DONE, Feedback, ProgressUpdate, console, instruction
+from toisto.ui.text import CONTINUE, DONE, Feedback, ProgressUpdate, console, instruction
 
 
 @dataclass(frozen=True)
@@ -37,8 +37,18 @@ class QuizMaster:
             evaluation = quiz.evaluate(guess, self.language_pair.source, attempt)
             retention = self.progress.mark_evaluation(quiz, evaluation)
             console.print(feedback.text(evaluation, guess, retention if self.show_quiz_retention else None))
+            if evaluation in (Evaluation.SKIPPED, Evaluation.INCORRECT):
+                self.wait_for_keypress()
             if evaluation in (Evaluation.CORRECT, Evaluation.SKIPPED):
                 break
+
+    def wait_for_keypress(self) -> None:
+        """Wait for the user to press Enter before showing the next quiz, so they can read the correct answer."""
+        console.print(CONTINUE, end="")
+        input()
+        # Move the cursor up and erase the "Press Enter" prompt. Flush so the escape reaches the terminal before
+        # the next output (e.g. the progress update), which is written through a different (Rich/dramatic) stream.
+        print("\033[F\033[2K", end="", flush=True)  # noqa: T201
 
     def do_quiz_attempt(self, quiz: Quiz, attempt: int) -> str:
         """Present the question and get the answer from the user."""

--- a/src/toisto/ui/style.py
+++ b/src/toisto/ui/style.py
@@ -9,6 +9,7 @@ theme = Theme(
         "language": "light_goldenrod2 bold",
         "progress": "light_sky_blue3",
         "quiz": "medium_purple1",
+        "continue": "dark_orange",
         "answer": "grey69",
         "secondary": "grey69",
         "colloquial": "grey69",

--- a/src/toisto/ui/text.py
+++ b/src/toisto/ui/text.py
@@ -38,7 +38,8 @@ Practice as many words and phrases as you like, for as long as you like.
 a quiz correctly, {NAME} will wait longer before repeating it. If you
 answer incorrectly, you get one additional attempt to give the correct
 answer. If the second attempt is not correct either, {NAME} will reset
-the quiz interval.
+the quiz interval. Whenever the correct answer is shown, {NAME} waits
+for you to press Enter before showing the next quiz, so you can read it.
 
 How does it work?
 ● To answer a quiz: type the answer, followed by Enter.
@@ -62,6 +63,8 @@ CONFIG_LANGUAGE_TIP: Final[str] = (
 DONE: Final[str] = f"""👍 Good job. You're done for now. Please come back later or try a different concept.
 [secondary]Type `{NAME.lower()} -h` for more information.[/secondary]
 """
+
+CONTINUE: Final[str] = "[continue]Press Enter to continue.[/continue] "
 
 
 class Feedback:

--- a/tests/toisto/command/test_practice.py
+++ b/tests/toisto/command/test_practice.py
@@ -14,7 +14,7 @@ from toisto.model.quiz.quiz_factory import create_quizzes
 from toisto.model.quiz.quiz_type import ANTONYM, DICTATE, INTERPRET, PLURAL, READ, WRITE
 from toisto.persistence.config import default_config
 from toisto.ui.dictionary import linkified
-from toisto.ui.text import DONE, Feedback, ProgressUpdate
+from toisto.ui.text import CONTINUE, DONE, Feedback, ProgressUpdate
 
 from ...base import FI_NL, NL_FI, ToistoTestCase
 
@@ -126,7 +126,7 @@ class PracticeAnswerTest(PracticeBase):
         patched_print = self.practice(FI_NL, quizzes)
         self.assert_printed(Feedback.CORRECT, patched_print)
 
-    @patch("builtins.input", Mock(side_effect=["H o i!\n", "Ho i!\n"]))
+    @patch("builtins.input", Mock(side_effect=["H o i!\n", "Ho i!\n", "\n"]))
     def test_answer_with_spaces(self):
         """Test that answers with spaces inside are not considered correct."""
         concept = self.create_concept_fixture()
@@ -346,7 +346,7 @@ class PracticeFeedbackTest(PracticeBase):
 """
         self.assert_printed(expected_feedback, patched_print)
 
-    @patch("builtins.input", Mock(side_effect=["incorrect\n", "incorrect again\n"]))
+    @patch("builtins.input", Mock(side_effect=["incorrect\n", "incorrect again\n", "\n"]))
     def test_quiz_with_multiple_antonyms(self):
         """Test that the correct meaning of the antonyms is given."""
         son = self.create_concept(
@@ -406,6 +406,76 @@ class PracticeLifeCycleTest(PracticeBase):
         patched_print = self.practice(FI_NL, quizzes)
         self.assert_printed(Feedback.TRY_AGAIN, patched_print)
         self.assert_printed(f"The correct answer is '{linkified('Hoi!')}'\n", patched_print)
+
+    @patch("builtins.input")
+    def test_pause_after_incorrect_answer(self, input_: Mock) -> None:
+        """Test that the user must press Enter after an incorrect answer before the next quiz is shown."""
+        input_.side_effect = ["incorrect\n", "incorrect again\n", "\n"]
+        concept = self.create_concept_fixture()
+        quizzes = create_quizzes(FI_NL, (READ,), concept)
+        patched_print = self.practice(FI_NL, quizzes)
+        self.assert_printed(CONTINUE, patched_print, end="")
+
+    @patch("builtins.input", Mock(side_effect=["incorrect\n", "incorrect again\n", "\n"]))
+    @patch("builtins.print")
+    def test_pause_prompt_is_erased(self, print_: Mock) -> None:
+        """Test that the "Press Enter to continue" prompt is erased after the user presses Enter."""
+        concept = self.create_concept_fixture()
+        quizzes = create_quizzes(FI_NL, (READ,), concept)
+        self.practice(FI_NL, quizzes)
+        self.assertIn(call("\033[F\033[2K", end="", flush=True), print_.call_args_list)
+
+    @patch("builtins.input")
+    def test_no_pause_after_correct_answer(self, input_: Mock) -> None:
+        """Test that the user is not paused after a correct answer."""
+        input_.side_effect = ["Hoi\n", EOFError]
+        concept = self.create_concept_fixture()
+        quizzes = create_quizzes(FI_NL, (READ,), concept)
+        patched_print = self.practice(FI_NL, quizzes)
+        self.assert_not_printed(CONTINUE, patched_print, end="")
+
+    @patch("builtins.input")
+    def test_pause_after_skip_on_first_attempt(self, input_: Mock) -> None:
+        """Test that the user must press Enter after skipping on the first attempt before the next quiz is shown."""
+        input_.side_effect = ["?\n", EOFError]
+        concept = self.create_concept_fixture()
+        quizzes = create_quizzes(FI_NL, (READ,), concept)
+        patched_print = self.practice(FI_NL, quizzes)
+        self.assert_printed(CONTINUE, patched_print, end="")
+
+    @patch("builtins.input")
+    def test_pause_after_skip_on_second_attempt(self, input_: Mock) -> None:
+        """Test that the user must press Enter after skipping on the second attempt before the next quiz is shown."""
+        input_.side_effect = ["incorrect\n", "?\n", EOFError]
+        concept = self.create_concept_fixture()
+        quizzes = create_quizzes(FI_NL, (READ,), concept)
+        patched_print = self.practice(FI_NL, quizzes)
+        self.assert_printed(CONTINUE, patched_print, end="")
+
+    @patch("builtins.input")
+    def test_no_pause_after_correct_second_attempt(self, input_: Mock) -> None:
+        """Test that the user is not paused when the second attempt is correct."""
+        input_.side_effect = ["incorrect\n", "Hoi\n", EOFError]
+        concept = self.create_concept_fixture()
+        quizzes = create_quizzes(FI_NL, (READ,), concept)
+        patched_print = self.practice(FI_NL, quizzes)
+        self.assert_not_printed(CONTINUE, patched_print, end="")
+
+    @patch("builtins.input", Mock(side_effect=["incorrect\n", "incorrect again\n", EOFError]))
+    def test_quit_with_ctrl_d_on_pause(self):
+        """Test that the user can quit cleanly by pressing Ctrl-D on the pause after an incorrect answer."""
+        concept = self.create_concept_fixture()
+        quizzes = create_quizzes(FI_NL, (READ,), concept)
+        patched_print = self.practice(FI_NL, quizzes)
+        self.assertEqual(call(), patched_print.call_args_list[-1])
+
+    @patch("builtins.input", Mock(side_effect=["?\n", KeyboardInterrupt]))
+    def test_quit_with_ctrl_c_on_pause(self):
+        """Test that the user can quit cleanly by pressing Ctrl-C on the pause after a skipped answer."""
+        concept = self.create_concept_fixture()
+        quizzes = create_quizzes(FI_NL, (READ,), concept)
+        patched_print = self.practice(FI_NL, quizzes)
+        self.assertEqual(call(), patched_print.call_args_list[-1])
 
     @patch("builtins.input", Mock(side_effect=["hoi\n", "hoi\n"]))
     def test_quiz_done(self):
@@ -470,7 +540,7 @@ class PracticeProgressTest(PracticeBase):
         progress_update = ProgressUpdate(progress, 1)
         self.assert_printed(progress_update(), patched_print, end="", highlight=False)
 
-    @patch("builtins.input", Mock(side_effect=["incorrect\n", "incorrect again\n"]))
+    @patch("builtins.input", Mock(side_effect=["incorrect\n", "incorrect again\n", "\n"]))
     def test_progress_after_incorrect_answer(self):
         """Test that progress is shown after an incorrect answer."""
         concept = self.create_concept_fixture()


### PR DESCRIPTION
Wait for the user to press Enter after an incorrectly answered or skipped quiz before showing the next quiz, so the correct answer can be read.

Fixes #1283.