### PR TITLE
Speak the answer after an incorrect/skipped answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/) 
 ### Added
 
 - Wait for the user to press Enter after an incorrectly answered or skipped quiz before showing the next quiz, so the correct answer can be read. Fixes [#1283](https://github.com/fniessink/toisto/issues/1283).
+- Speak the correct answer after an incorrectly answered or skipped quiz, when the answer is in the target language. Fixes [#1284](https://github.com/fniessink/toisto/issues/1284).
 
 ## 0.42.0 - 2026-06-06
 

--- a/src/toisto/command/practice.py
+++ b/src/toisto/command/practice.py
@@ -38,9 +38,15 @@ class QuizMaster:
             retention = self.progress.mark_evaluation(quiz, evaluation)
             console.print(feedback.text(evaluation, guess, retention if self.show_quiz_retention else None))
             if evaluation in (Evaluation.SKIPPED, Evaluation.INCORRECT):
+                self.say_answer(quiz)
                 self.wait_for_keypress()
             if evaluation in (Evaluation.CORRECT, Evaluation.SKIPPED):
                 break
+
+    def say_answer(self, quiz: Quiz) -> None:
+        """Say the correct answer, but only if it is in the target language; no need to speak the source language."""
+        if quiz.answer.language == self.language_pair.target:
+            self.speech.say(quiz.answer.language, quiz.answer.pronounceable, slow=True)
 
     def wait_for_keypress(self) -> None:
         """Wait for the user to press Enter before showing the next quiz, so they can read the correct answer."""

--- a/tests/toisto/command/test_practice.py
+++ b/tests/toisto/command/test_practice.py
@@ -206,6 +206,49 @@ class PracticeAnswerTest(PracticeBase):
 @patch("pathlib.Path.open", MagicMock())
 @patch("toisto.ui.speech.gTTS", Mock())
 @patch("toisto.ui.speech.Popen", Mock())
+class PracticeSpeakAnswerTest(PracticeBase):
+    """Test that the correct answer is spoken after an incorrect or skipped answer."""
+
+    @patch("builtins.input", Mock(side_effect=["incorrect\n", "incorrect again\n", "\n"]))
+    @patch("toisto.command.practice.Speech.say")
+    def test_speak_answer_after_incorrect_answer(self, say: Mock) -> None:
+        """Test that the correct answer is spoken after an incorrect answer when it is in the target language."""
+        concept = self.create_concept_fixture()
+        quizzes = create_quizzes(FI_NL, (WRITE,), concept)
+        self.practice(FI_NL, quizzes)
+        self.assertIn(call(FI, "Terve!", slow=True), say.call_args_list)
+
+    @patch("builtins.input", Mock(side_effect=["?\n", EOFError]))
+    @patch("toisto.command.practice.Speech.say")
+    def test_speak_answer_after_skipped_answer(self, say: Mock) -> None:
+        """Test that the correct answer is spoken after a skipped answer when it is in the target language."""
+        concept = self.create_concept_fixture()
+        quizzes = create_quizzes(FI_NL, (WRITE,), concept)
+        self.practice(FI_NL, quizzes)
+        self.assertIn(call(FI, "Terve!", slow=True), say.call_args_list)
+
+    @patch("builtins.input", Mock(side_effect=["incorrect\n", "incorrect again\n", "\n"]))
+    @patch("toisto.command.practice.Speech.say")
+    def test_do_not_speak_answer_in_source_language(self, say: Mock) -> None:
+        """Test that the correct answer is not spoken when it is in the source language."""
+        concept = self.create_concept_fixture()
+        quizzes = create_quizzes(FI_NL, (READ,), concept)
+        self.practice(FI_NL, quizzes)
+        self.assertNotIn(call(NL, "Hoi!", slow=True), say.call_args_list)
+
+    @patch("builtins.input", Mock(return_value="Terve!\n"))
+    @patch("toisto.command.practice.Speech.say")
+    def test_do_not_speak_answer_after_correct_answer(self, say: Mock) -> None:
+        """Test that the correct answer is not spoken after a correct answer."""
+        concept = self.create_concept_fixture()
+        quizzes = create_quizzes(FI_NL, (WRITE,), concept)
+        self.practice(FI_NL, quizzes)
+        self.assertNotIn(call(FI, "Terve!", slow=True), say.call_args_list)
+
+
+@patch("pathlib.Path.open", MagicMock())
+@patch("toisto.ui.speech.gTTS", Mock())
+@patch("toisto.ui.speech.Popen", Mock())
 class PracticeFeedbackTest(PracticeBase):
     """Test the practice command feedback."""
 


### PR DESCRIPTION
Speak the correct answer after an incorrectly answered or skipped quiz, when the answer is in the target language.

Fixes #1284.